### PR TITLE
Use open file descriptors to retain file between prepare and marshal phases

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -58,25 +58,27 @@ exports.response = function (path, options, request) {
     var source = {
         path: Path.normalize(Hoek.isAbsolutePath(path) ? path : Path.join(request.route.files.relativeTo, path)),
         settings: options,
-        stat: null
+        stat: null,
+        fd: null
     };
 
-    return request.generateResponse(source, { variety: 'file', marshal: internals.marshal, prepare: internals.prepare });
+    return request.generateResponse(source, { variety: 'file', marshal: internals.marshal, prepare: internals.prepare, close: internals.close });
 };
 
 
 internals.prepare = function (response, callback) {
 
+    // close any leftover descriptors from previous prepare call
+    internals.close(response);
+
     var path = response.source.path;
-    Fs.stat(path, function (err, stat) {
+    internals.openStat(path, 'r', function (err, fd, stat) {
 
         if (err) {
-            return callback(Boom.notFound());
+            return callback(err);
         }
 
-        if (stat.isDirectory()) {
-            return callback(Boom.forbidden());
-        }
+        response.source.fd = fd;
 
         response.bytes(stat.size);
 
@@ -132,13 +134,14 @@ internals.marshal = function (response, callback) {
     }
 
     var gzFile = response.source.path + '.gz';
-    Fs.stat(gzFile, function (err, stat) {
+    internals.openStat(gzFile, 'r', function (err, fd, stat) {
 
-        if (err ||
-            stat.isDirectory()) {
-
+        if (err) {
             return internals.openStream(response, response.source.path, callback);
         }
+
+        internals.close(response);
+        response.source.fd = fd;
 
         response.bytes(stat.size);
         response.header('content-encoding', 'gzip');
@@ -151,22 +154,50 @@ internals.marshal = function (response, callback) {
 
 internals.openStream = function (response, path, callback) {
 
-    var fileStream = Fs.createReadStream(path);
+    Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
 
-    var onError = function (err) {
+    var fileStream = Fs.createReadStream(path, { fd: response.source.fd });
 
-        fileStream.removeListener('open', onOpen);
-        return callback(err);
-    };
+    // claim descriptor
+    response.source.fd = null;
 
-    var onOpen = function () {
+    // callback immediately since descriptors are already open
+    return callback(null, fileStream);
+};
 
-        fileStream.removeListener('error', onError);
-        return callback(null, fileStream);
-    };
 
-    fileStream.once('error', onError);
-    fileStream.once('open', onOpen);
+internals.openStat = function (path, mode, callback) {
+
+    Fs.open(path, mode, function(err, fd) {
+
+        if (err) {
+            return callback(Boom.notFound());
+        }
+
+        Fs.fstat(fd, function(err, stat) {
+
+            if (err) {
+                Fs.close(fd, Hoek.ignore);
+                return callback(Boom.wrap(err, null, 'failed to stat file'));
+            }
+
+            if (stat.isDirectory()) {
+                Fs.close(fd, Hoek.ignore);
+                return callback(Boom.forbidden());
+            }
+
+            return callback(null, fd, stat);
+        });
+    });
+};
+
+
+internals.close = function (response) {
+
+    if (response.source.fd !== null) {
+        Fs.close(response.source.fd, Hoek.ignore);
+        response.source.fd = null;
+    }
 };
 
 


### PR DESCRIPTION
WIP patch to fix #4, including new & updated tests.

This patch seems to work as is, and passes all test on my machine. However, it doesn't have 100% code coverage due to never triggering the `Fs.fstat()` error response. Given that this is only likely to trigger on messed up filesystems with an `EIO` error, I'm at a loss on how to test for this. Perhaps some kind of mocking?

I also have concerns about forgetting open file descriptors. I do ensure that they are closed whenever `finish` is triggered on the response but I found no such hooks for error'ed responses, which is needed for this to work. Am I missing something?
