### PR TITLE
Fix option parsing to match hapi documentation

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -18,7 +18,7 @@ internals.schema = Joi.alternatives([
     Joi.string(),
     Joi.func(),
     Joi.object({
-        path: Joi.string().required(),
+        path: Joi.alternatives(Joi.string(), Joi.func()).required(),
         filename: Joi.string(),
         mode: Joi.string().valid('attachment', 'inline').allow(false),
         lookupCompressed: Joi.boolean()
@@ -30,7 +30,7 @@ internals.schema = Joi.alternatives([
 exports.handler = function (route, options) {
 
     Joi.assert(options, internals.schema, 'Invalid file handler options (' + route.path + ')');
-    var settings = (typeof options !== 'object' ? { path: options } : Hoek.clone(options));                        // options can be reused
+    var settings = (typeof options !== 'object' ? { path: options } : Joi.validate(options, internals.schema).value);
     Hoek.assert(typeof settings.path !== 'string' || settings.path[settings.path.length - 1] !== '/', 'File path cannot end with a \'/\':', route.path);
 
     var handler = function (request, reply) {

--- a/test/file.js
+++ b/test/file.js
@@ -811,8 +811,9 @@ describe('file', function () {
 
             var fn = function () {
 
-                var server = provisionServer(__dirname);
+                var server = provisionServer();
                 server.route({ method: 'GET', path: '/fileparam/{path}', handler: { file: function () { } } });
+                server.route({ method: 'GET', path: '/filepathparam/{path}', handler: { file: { path: function () { } } } });
             };
 
             expect(fn).to.not.throw();


### PR DESCRIPTION
Allow function param in `path`, and convert `lookupCompressed` stringified booleans to actual booleans.
