### PR TITLE
Handle Range requests explicitly

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -3,6 +3,7 @@
 var Fs = require('fs');
 var Path = require('path');
 var Crypto = require('crypto');
+var Ammo = require('ammo');
 var Boom = require('boom');
 var Hoek = require('hoek');
 var Joi = require('joi');
@@ -129,14 +130,14 @@ internals.marshal = function (response, next) {
     if (!response.source.settings.lookupCompressed ||
         response.request.info.acceptEncoding !== 'gzip') {
 
-        return next(null, internals.openStream(response, response.source.path));
+        return internals.openStream(response, response.source.path, next);
     }
 
     var gzFile = response.source.path + '.gz';
     internals.openStat(gzFile, 'r', function (err, fd, stat) {
 
         if (err) {
-            return next(null, internals.openStream(response, response.source.path));
+            return internals.openStream(response, response.source.path, next);
         }
 
         internals.close(response);
@@ -146,18 +147,56 @@ internals.marshal = function (response, next) {
         response.header('content-encoding', 'gzip');
         response.vary('accept-encoding');
 
-        return next(null, internals.openStream(response, gzFile));
+        return internals.openStream(response, gzFile, next);
     });
 };
 
 
-internals.openStream = function (response, path) {
+internals.openStream = function (response, path, next) {
 
     Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
 
-    var fileStream = Fs.createReadStream(path, { fd: response.source.fd });
+    // Check for Range request
+
+    var request = response.request;
+    var length = response.headers['content-length'];
+    var options = { fd: response.source.fd };
+
+    if (request.headers.range && length) {
+
+        // Check If-Range
+
+        if (!request.headers['if-range'] ||
+            request.headers['if-range'] === response.headers.etag) {            // Ignoring last-modified date (weak)
+
+            // Parse header
+
+            var ranges = Ammo.header(request.headers.range, length);
+            if (!ranges) {
+                var error = Boom.rangeNotSatisfiable();
+                error.output.headers['content-range'] = 'bytes */' + length;
+                return next(error);
+            }
+
+            // Prepare transform
+
+            if (ranges.length === 1) {                                          // Ignore requests for multiple ranges
+                var range = ranges[0];
+                response.code(206);
+                response.bytes(range.to - range.from + 1);
+                response._header('content-range', 'bytes ' + range.from + '-' + range.to + '/' + length);
+
+                options.start = range.from;
+                options.end = range.to;
+            }
+        }
+    }
+
+    response._header('accept-ranges', 'bytes');
+
+    var fileStream = Fs.createReadStream(path, options);
     response.source.fd = null;              // Claim descriptor
-    return fileStream;
+    return next(null, fileStream);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node": ">=0.10.32"
   },
   "dependencies": {
+    "ammo": "1.x.x",
     "boom": "2.x.x",
     "hoek": "2.x.x",
     "items": "1.x.x",


### PR DESCRIPTION
Fixes #6.

Note that all but the last test are copied from hapi. Additionally, I expect that this update will require the hapi tests to be reworked since the accept logic is no longer exercised for file responses.