### PR TITLE
Replace 404 response with 403 and 500 when appropriate

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -205,7 +205,15 @@ internals.openStat = function (path, mode, callback) {
     Fs.open(path, mode, function(err, fd) {
 
         if (err) {
-            return callback(Boom.notFound());
+            if (err.code === 'ENOENT') {
+                return callback(Boom.notFound());
+            }
+
+            if (err.code === 'EACCES' || err.code === 'EPERM') {
+                return callback(Boom.forbidden());
+            }
+
+            return callback(Boom.wrap(err, null, 'failed to open file'));
         }
 
         Fs.fstat(fd, function(err, stat) {


### PR DESCRIPTION
This fixes a somewhat serious issue where clients would get a `404` responses when `open` fails because of `EMFILE`, etc. This should not happen for this kind of ephemeral error.

The patch will now only return `404` when the filesystem reports `ENOENT`. Otherwise, it will detect permission errors and return `403` responses to indicate this, and finally it can fail with an internal error, exposing the actual error.