### PR TITLE
io.js support for null byte path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: node_js
 node_js:
   - 0.10
   - 0.11
-
+  - iojs

--- a/lib/file.js
+++ b/lib/file.js
@@ -213,9 +213,12 @@ internals.openStat = function (path, mode, callback) {
                 return callback(Boom.forbidden(null, err.code));
             }
 
+            // Fixed in io.js 1.1 : https://github.com/iojs/io.js/issues/517
+            // $lab:coverage:off$
             if (path.indexOf('\u0000') !== -1) {      // handle "Path must be a string without null bytes" error
                 return callback(Boom.notFound());
             }
+            // $lab:coverage:on$
 
             return callback(Boom.wrap(err, null, 'Failed to open file'));
         }

--- a/test/directory.js
+++ b/test/directory.js
@@ -802,7 +802,7 @@ describe('directory', function () {
             });
         });
 
-        it('returns a 403 for null byte paths', function (done) {
+        it('returns a 404 for null byte paths', function (done) {
 
             var server = provisionServer();
             server.route({ method: 'GET', path: '/{path*}', handler: { directory: { path: './' } } });


### PR DESCRIPTION
The null byte path traversal is fixed for io.js in https://github.com/iojs/io.js/issues/517 and returns an ENOENT.
We have a different behavior between node and io here, maybe it should be homogenized by returning a 404 instead of 403.