### PR TITLE
Never store ETags computed on partial data

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -102,15 +102,19 @@ internals.prepare = function (response, callback) {
             }
             else {
                 var hash = Crypto.createHash('sha1');
+                var processed = 0;
                 response.on('peek', function (chunk) {
 
                     hash.update(chunk);
+                    processed += chunk.length;
                 });
 
                 response.once('finish', function () {
 
-                    var etag = hash.digest('hex');
-                    etags.set(cachekey, etag);
+                    if (processed === stat.size) {
+                        var etag = hash.digest('hex');
+                        etags.set(cachekey, etag);
+                    }
                 });
             }
         }


### PR DESCRIPTION
This fixes #27 by checking that all bytes have been processed before caching the ETag.

I have included two tests that would fail on the old code.

/cc @hueniverse for review.