### PR TITLE
Add new etaging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ type based on filename extension.:
       - `lookupCompressed` - if `true`, looks for the same filename with the '.gz' suffix for a
         pre-compressed version of the file to serve if the request supports content encoding.
         Defaults to `false`.
+      - `etagMethod` - specifies the method used to calculate the `ETag` header response.
+        Available values:
+          - `'hash'` - SHA1 sum of the file contents, suitable for distributed deployments.
+            Default value.
+          - `'simple'` - Hex encoded size and modification date, suitable when files are stored
+            on a single server.
+          - `false` - Disable ETag computation.
 
 Returns a standard [response](https://github.com/hapijs/hapi/blob/master/API.md#response-object) object.
 
@@ -185,6 +192,13 @@ Generates a static file endpoint for serving a single file. `file` can be set to
       - `lookupCompressed` - if `true`, looks for the same filename with the '.gz' suffix
         for a pre-compressed version of the file to serve if the request supports content
         encoding. Defaults to `false`.
+      - `etagMethod` - specifies the method used to calculate the `ETag` header response.
+        Available values:
+          - `'hash'` - SHA1 sum of the file contents, suitable for distributed deployments.
+            Default value.
+          - `'simple'` - Hex encoded size and modification date, suitable when files are stored
+            on a single server.
+          - `false` - Disable ETag computation.
 
 ### The `directory` handler
 
@@ -222,5 +236,12 @@ object with the following options:
   - `lookupCompressed` - optional boolean, instructs the file processor to look for the same
     filename with the '.gz' suffix for a pre-compressed version of the file to serve if the
     request supports content encoding. Defaults to `false`.
+  - `etagMethod` - specifies the method used to calculate the `ETag` header response.
+    Available values:
+      - `'hash'` - SHA1 sum of the file contents, suitable for distributed deployments.
+        Default value.
+      - `'simple'` - Hex encoded size and modification date, suitable when files are stored
+        on a single server.
+      - `false` - Disable ETag computation.
   - `defaultExtension` - optional string, appended to file requests if the requested file is
     not found. Defaults to no extension.

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -21,6 +21,7 @@ internals.schema = Joi.object({
     showHidden: Joi.boolean(),
     redirectToSlash: Joi.boolean(),
     lookupCompressed: Joi.boolean(),
+    etagMethod: Joi.string().valid('hash', 'simple').allow(false),
     defaultExtension: Joi.string().alphanum()
 });
 
@@ -95,12 +96,13 @@ exports.handler = function (route, options) {
 
         var resource = request.path;
         var hasTrailingSlash = (resource[resource.length - 1] === '/');
+        var fileOptions = { lookupCompressed: settings.lookupCompressed, etagMethod: settings.etagMethod };
 
         Items.serial(paths, function (path, nextPath) {
 
             path = Path.join(path, selection || '');
 
-            File.load(path, request, { lookupCompressed: settings.lookupCompressed }, function (response) {
+            File.load(path, request, fileOptions, function (response) {
 
                 // File loaded successfully
 
@@ -120,7 +122,7 @@ exports.handler = function (route, options) {
                         path = path.slice(0, -1);
                     }
 
-                    return File.load(path + '.' + settings.defaultExtension, request, { lookupCompressed: settings.lookupCompressed }, function (extResponse) {
+                    return File.load(path + '.' + settings.defaultExtension, request, fileOptions, function (extResponse) {
 
                         if (!extResponse.isBoom) {
                             return reply(extResponse);
@@ -154,7 +156,7 @@ exports.handler = function (route, options) {
                 Items.serial(indexNames, function (indexName, nextIndex) {
 
                     var indexFile = Path.join(path, indexName);
-                    File.load(indexFile, request, { lookupCompressed: settings.lookupCompressed }, function (indexResponse) {
+                    File.load(indexFile, request, fileOptions, function (indexResponse) {
 
                         // File loaded successfully
 

--- a/lib/etag.js
+++ b/lib/etag.js
@@ -12,11 +12,11 @@ var LruCache = require('lru-cache');
 var internals = {};
 
 
-internals.addHashedEtag = function (response, stat, callback) {
+internals.computeHashed = function (response, stat, callback) {
 
     var etags = response.request.server.plugins.inert._etags;
     if (!etags) {
-        return callback();
+        return callback(null, null);
     }
 
     // Use stat info for an LRU cache key.
@@ -28,16 +28,28 @@ internals.addHashedEtag = function (response, stat, callback) {
 
     var cachedEtag = etags.get(cachekey);
     if (cachedEtag) {
-        response.etag(cachedEtag, { vary: true });
-        return callback();
+        return callback(null, cachedEtag);
     }
 
-    // Perform the hashing
+    internals.hashFile(response, function (err, hash) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        etags.set(cachekey, hash);
+
+        return callback(null, hash);
+    });
+};
+
+
+internals.hashFile = function (response, callback) {
 
     var hash = Crypto.createHash('sha1');
     hash.setEncoding('hex');
 
-    var fileStream = Fs.createReadStream(path, { fd: response.source.fd, autoClose: false });
+    var fileStream = Fs.createReadStream(response.source.path, { fd: response.source.fd, autoClose: false });
     fileStream.pipe(hash);
 
     var done = function (err) {
@@ -46,12 +58,7 @@ internals.addHashedEtag = function (response, stat, callback) {
             return callback(Boom.wrap(err, null, 'Failed to hash file'));
         }
 
-        var etag = hash.read();
-        etags.set(cachekey, etag);
-
-        response.etag(etag, { vary: true });
-
-        return callback();
+        return callback(null, hash.read());
     };
 
     done = Hoek.once(done);
@@ -61,28 +68,40 @@ internals.addHashedEtag = function (response, stat, callback) {
 };
 
 
-internals.addSimpleEtag = function (response, stat, callback) {
+internals.computeSimple = function (response, stat, callback) {
 
     var size = stat.size.toString(16);
     var mtime = stat.mtime.getTime().toString(16);
 
-    response.etag(size + '-' + mtime, { vary: true });
-
-    return callback();
+    return callback(null, size + '-' + mtime);
 };
 
 
 exports.apply = function (response, stat, callback) {
 
-    if (response.source.settings.etagMethod === false) {
+    var etagMethod = response.source.settings.etagMethod;
+    if (etagMethod === false) {
         return callback();
     }
 
-    if (response.source.settings.etagMethod === 'simple') {
-        return internals.addSimpleEtag(response, stat, callback);
+    var applyEtag = function (err, etag) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        if (etag !== null) {
+            response.etag(etag, { vary: true });
+        }
+
+        return callback();
+    };
+
+    if (etagMethod === 'simple') {
+        return internals.computeSimple(response, stat, applyEtag);
     }
 
-    return internals.addHashedEtag(response, stat, callback);
+    return internals.computeHashed(response, stat, applyEtag);
 };
 
 

--- a/lib/etag.js
+++ b/lib/etag.js
@@ -12,11 +12,11 @@ var LruCache = require('lru-cache');
 var internals = {};
 
 
-internals.computeHashed = function (response, stat, callback) {
+internals.computeHashed = function (response, stat, next) {
 
     var etags = response.request.server.plugins.inert._etags;
     if (!etags) {
-        return callback(null, null);
+        return next(null, null);
     }
 
     // Use stat info for an LRU cache key.
@@ -28,17 +28,20 @@ internals.computeHashed = function (response, stat, callback) {
 
     var cachedEtag = etags.get(cachekey);
     if (cachedEtag) {
-        return callback(null, cachedEtag);
+        return next(null, cachedEtag);
     }
 
     var pendings = response.request.server.plugins.inert._pendings;
     var pendingsId = '+' + cachekey;                                  // Prefix to avoid conflicts with JS internals (e.g. __proto__)
-    var callbacks = pendings[pendingsId];
-    if (callbacks) {
-        return callbacks.push(callback);
+    var nexts = pendings[pendingsId];
+    if (nexts) {
+        return nexts.push(next);
     }
 
-    pendings[pendingsId] = callbacks = [callback];
+    // Start hashing
+
+    nexts = [next];
+    pendings[pendingsId] = nexts;
 
     internals.hashFile(response, function (err, hash) {
 
@@ -49,8 +52,8 @@ internals.computeHashed = function (response, stat, callback) {
         // Call pending callbacks
 
         delete pendings[pendingsId];
-        for (var i = 0, il = callbacks.length; i < il; ++i) {
-            Hoek.nextTick(callbacks[i])(err, hash);
+        for (var i = 0, il = nexts.length; i < il; ++i) {
+            Hoek.nextTick(nexts[i])(err, hash);
         }
     });
 };
@@ -80,33 +83,33 @@ internals.hashFile = function (response, callback) {
 };
 
 
-internals.computeSimple = function (response, stat, callback) {
+internals.computeSimple = function (response, stat, next) {
 
     var size = stat.size.toString(16);
     var mtime = stat.mtime.getTime().toString(16);
 
-    return callback(null, size + '-' + mtime);
+    return next(null, size + '-' + mtime);
 };
 
 
-exports.apply = function (response, stat, callback) {
+exports.apply = function (response, stat, next) {
 
     var etagMethod = response.source.settings.etagMethod;
     if (etagMethod === false) {
-        return callback();
+        return next();
     }
 
     var applyEtag = function (err, etag) {
 
         if (err) {
-            return callback(err);
+            return next(err);
         }
 
         if (etag !== null) {
             response.etag(etag, { vary: true });
         }
 
-        return callback();
+        return next();
     };
 
     if (etagMethod === 'simple') {

--- a/lib/etag.js
+++ b/lib/etag.js
@@ -1,0 +1,89 @@
+// Load modules
+
+var Fs = require('fs');
+var Crypto = require('crypto');
+var Boom = require('boom');
+var Hoek = require('hoek');
+var LruCache = require('lru-cache');
+
+
+// Declare internals
+
+var internals = {};
+
+
+internals.addHashedEtag = function (response, stat, callback) {
+
+    var etags = response.request.server.plugins.inert._etags;
+    if (!etags) {
+        return callback();
+    }
+
+    // Use stat info for an LRU cache key.
+
+    var path = response.source.path;
+    var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
+
+    // The etag hashes the file contents in order to be consistent across distributed deployments
+
+    var cachedEtag = etags.get(cachekey);
+    if (cachedEtag) {
+        response.etag(cachedEtag, { vary: true });
+        return callback();
+    }
+
+    // Perform the hashing
+
+    var hash = Crypto.createHash('sha1');
+    hash.setEncoding('hex');
+
+    var fileStream = Fs.createReadStream(path, { fd: response.source.fd, autoClose: false });
+    fileStream.pipe(hash);
+
+    var done = function (err) {
+
+        if (err) {
+            return callback(Boom.wrap(err, null, 'Failed to hash file'));
+        }
+
+        var etag = hash.read();
+        etags.set(cachekey, etag);
+
+        response.etag(etag, { vary: true });
+
+        return callback();
+    };
+
+    done = Hoek.once(done);
+
+    fileStream.on('end', done);
+    fileStream.on('error', done);
+};
+
+
+internals.addSimpleEtag = function (response, stat, callback) {
+
+    var size = stat.size.toString(16);
+    var mtime = stat.mtime.getTime().toString(16);
+
+    response.etag(size + '-' + mtime, { vary: true });
+
+    return callback();
+};
+
+
+exports.apply = function (response, stat, callback) {
+
+    if (response.source.settings.etagMethod === false) {
+        return callback();
+    }
+
+    if (response.source.settings.etagMethod === 'simple') {
+        return internals.addSimpleEtag(response, stat, callback);
+    }
+
+    return internals.addHashedEtag(response, stat, callback);
+};
+
+
+exports.Cache = LruCache;

--- a/lib/etag.js
+++ b/lib/etag.js
@@ -31,15 +31,27 @@ internals.computeHashed = function (response, stat, callback) {
         return callback(null, cachedEtag);
     }
 
+    var pendings = response.request.server.plugins.inert._pendings;
+    var pendingsId = '+' + cachekey;                                  // Prefix to avoid conflicts with JS internals (e.g. __proto__)
+    var callbacks = pendings[pendingsId];
+    if (callbacks) {
+        return callbacks.push(callback);
+    }
+
+    pendings[pendingsId] = callbacks = [callback];
+
     internals.hashFile(response, function (err, hash) {
 
-        if (err) {
-            return callback(err);
+        if (!err) {
+            etags.set(cachekey, hash);
         }
 
-        etags.set(cachekey, hash);
+        // Call pending callbacks
 
-        return callback(null, hash);
+        delete pendings[pendingsId];
+        for (var i = 0, il = callbacks.length; i < il; ++i) {
+            Hoek.nextTick(callbacks[i])(err, hash);
+        }
     });
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -22,7 +22,8 @@ internals.schema = Joi.alternatives([
         path: Joi.alternatives(Joi.string(), Joi.func()).required(),
         filename: Joi.string(),
         mode: Joi.string().valid('attachment', 'inline').allow(false),
-        lookupCompressed: Joi.boolean()
+        lookupCompressed: Joi.boolean(),
+        etagMethod: Joi.string().valid('hash', 'simple').allow(false)
     })
         .with('filename', 'mode')
 ]);
@@ -128,7 +129,7 @@ internals.marshal = function (response, next) {
 };
 
 
-internals.addEtag = function (response, stat, callback) {
+internals.addHashedEtag = function (response, stat, callback) {
 
     var etags = response.request.server.plugins.inert._etags;
     if (etags) {
@@ -164,6 +165,31 @@ internals.addEtag = function (response, stat, callback) {
     }
 
     return callback();
+};
+
+
+internals.addSimpleEtag = function (response, stat, callback) {
+
+    var size = stat.size.toString(16);
+    var mtime = stat.mtime.getTime().toString(16);
+
+    response.etag(size + '-' + mtime, { vary: true });
+
+    return callback();
+};
+
+
+internals.addEtag = function (response, stat, callback) {
+
+    if (response.source.settings.etagMethod === false) {
+        return callback();
+    }
+
+    if (response.source.settings.etagMethod === 'simple') {
+        return internals.addSimpleEtag(response, stat, callback);
+    }
+
+    return internals.addHashedEtag(response, stat, callback);
 };
 
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -95,6 +95,7 @@ internals.prepare = function (response, callback) {
         Etag.apply(response, stat, function (err) {
 
             if (err) {
+                internals.close(response);
                 return callback(err);
             }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -87,44 +87,15 @@ internals.prepare = function (response, callback) {
 
         response.header('last-modified', stat.mtime.toUTCString());
 
-        var etags = response.request.server.plugins.inert._etags;
-        if (etags) {
-
-            // Use stat info for an LRU cache key.
-
-            var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
-
-            // The etag must hash the file contents in order to be consistent across distributed deployments
-
-            var cachedEtag = etags.get(cachekey);
-            if (cachedEtag) {
-                response.etag(cachedEtag, { vary: true });
-            }
-            else {
-                var hash = Crypto.createHash('sha1');
-                var processed = 0;
-                response.on('peek', function (chunk) {
-
-                    hash.update(chunk);
-                    processed += chunk.length;
-                });
-
-                response.once('finish', function () {
-
-                    if (processed === stat.size) {
-                        var etag = hash.digest('hex');
-                        etags.set(cachekey, etag);
-                    }
-                });
-            }
-        }
-
         if (response.source.settings.mode) {
             var fileName = response.source.settings.filename || Path.basename(path);
             response.header('content-disposition', response.source.settings.mode + '; filename=' + encodeURIComponent(fileName));
         }
 
-        return callback(response);
+        internals.addEtag(response, stat, function () {
+
+            return callback(response);
+        });
     });
 };
 
@@ -157,15 +128,50 @@ internals.marshal = function (response, next) {
 };
 
 
-internals.openStream = function (response, path, next) {
+internals.addEtag = function (response, stat, callback) {
 
-    Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
+    var etags = response.request.server.plugins.inert._etags;
+    if (etags) {
 
-    // Check for Range request
+        // Use stat info for an LRU cache key.
+
+        var path = response.source.path;
+        var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
+
+        // The etag must hash the file contents in order to be consistent across distributed deployments
+
+        var cachedEtag = etags.get(cachekey);
+        if (cachedEtag) {
+            response.etag(cachedEtag, { vary: true });
+        }
+        else {
+            var hash = Crypto.createHash('sha1');
+            var processed = 0;
+            response.on('peek', function (chunk) {
+
+                hash.update(chunk);
+                processed += chunk.length;
+            });
+
+            response.once('finish', function () {
+
+                if (processed === stat.size) {
+                    var etag = hash.digest('hex');
+                    etags.set(cachekey, etag);
+                }
+            });
+        }
+    }
+
+    return callback();
+};
+
+
+internals.addContentRange = function (response, callback) {
 
     var request = response.request;
     var length = response.headers['content-length'];
-    var options = { fd: response.source.fd };
+    var range = null;
 
     if (request.headers.range && length) {
 
@@ -180,28 +186,48 @@ internals.openStream = function (response, path, next) {
             if (!ranges) {
                 var error = Boom.rangeNotSatisfiable();
                 error.output.headers['content-range'] = 'bytes */' + length;
-                return next(error);
+                return callback(error);
             }
 
             // Prepare transform
 
             if (ranges.length === 1) {                                          // Ignore requests for multiple ranges
-                var range = ranges[0];
+                range = ranges[0];
                 response.code(206);
                 response.bytes(range.to - range.from + 1);
                 response.header('content-range', 'bytes ' + range.from + '-' + range.to + '/' + length);
-
-                options.start = range.from;
-                options.end = range.to;
             }
         }
     }
 
     response.header('accept-ranges', 'bytes');
 
-    var fileStream = Fs.createReadStream(path, options);
-    response.source.fd = null;              // Claim descriptor
-    return next(null, fileStream);
+    return callback(null, range);
+};
+
+
+internals.openStream = function (response, path, next) {
+
+    Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
+
+    var options = { fd: response.source.fd };
+
+    internals.addContentRange(response, function (err, range) {
+
+        if (err) {
+            return next(err);
+        }
+
+        if (range) {
+            options.start = range.from;
+            options.end = range.to;
+        }
+
+        var fileStream = Fs.createReadStream(path, options);
+        response.source.fd = null;              // Claim descriptor
+
+        return next(null, fileStream);
+    });
 };
 
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -2,12 +2,11 @@
 
 var Fs = require('fs');
 var Path = require('path');
-var Crypto = require('crypto');
 var Ammo = require('ammo');
 var Boom = require('boom');
 var Hoek = require('hoek');
 var Joi = require('joi');
-var LruCache = require('lru-cache');
+var Etag = require('./etag');
 
 
 // Declare internals
@@ -93,7 +92,7 @@ internals.prepare = function (response, callback) {
             response.header('content-disposition', response.source.settings.mode + '; filename=' + encodeURIComponent(fileName));
         }
 
-        internals.addEtag(response, stat, function (err) {
+        Etag.apply(response, stat, function (err) {
 
             if (err) {
                 return callback(err);
@@ -130,80 +129,6 @@ internals.marshal = function (response, next) {
 
         return internals.openStream(response, gzFile, next);
     });
-};
-
-
-internals.addHashedEtag = function (response, stat, callback) {
-
-    var etags = response.request.server.plugins.inert._etags;
-    if (!etags) {
-        return callback();
-    }
-
-    // Use stat info for an LRU cache key.
-
-    var path = response.source.path;
-    var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
-
-    // The etag hashes the file contents in order to be consistent across distributed deployments
-
-    var cachedEtag = etags.get(cachekey);
-    if (cachedEtag) {
-        response.etag(cachedEtag, { vary: true });
-        return callback();
-    }
-
-    // Perform the hashing
-
-    var hash = Crypto.createHash('sha1');
-    hash.setEncoding('hex');
-
-    var fileStream = Fs.createReadStream(path, { fd: response.source.fd, autoClose: false });
-    fileStream.pipe(hash);
-
-    var done = function (err) {
-
-        if (err) {
-            return callback(Boom.wrap(err, null, 'Failed to hash file'));
-        }
-
-        var etag = hash.read();
-        etags.set(cachekey, etag);
-
-        response.etag(etag, { vary: true });
-
-        return callback();
-    };
-
-    done = Hoek.once(done);
-
-    fileStream.on('end', done);
-    fileStream.on('error', done);
-};
-
-
-internals.addSimpleEtag = function (response, stat, callback) {
-
-    var size = stat.size.toString(16);
-    var mtime = stat.mtime.getTime().toString(16);
-
-    response.etag(size + '-' + mtime, { vary: true });
-
-    return callback();
-};
-
-
-internals.addEtag = function (response, stat, callback) {
-
-    if (response.source.settings.etagMethod === false) {
-        return callback();
-    }
-
-    if (response.source.settings.etagMethod === 'simple') {
-        return internals.addSimpleEtag(response, stat, callback);
-    }
-
-    return internals.addHashedEtag(response, stat, callback);
 };
 
 
@@ -312,6 +237,3 @@ internals.close = function (response) {
         response.source.fd = null;
     }
 };
-
-
-exports.Etags = LruCache;

--- a/lib/file.js
+++ b/lib/file.js
@@ -93,7 +93,11 @@ internals.prepare = function (response, callback) {
             response.header('content-disposition', response.source.settings.mode + '; filename=' + encodeURIComponent(fileName));
         }
 
-        internals.addEtag(response, stat, function () {
+        internals.addEtag(response, stat, function (err) {
+
+            if (err) {
+                return callback(err);
+            }
 
             return callback(response);
         });
@@ -132,39 +136,49 @@ internals.marshal = function (response, next) {
 internals.addHashedEtag = function (response, stat, callback) {
 
     var etags = response.request.server.plugins.inert._etags;
-    if (etags) {
-
-        // Use stat info for an LRU cache key.
-
-        var path = response.source.path;
-        var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
-
-        // The etag must hash the file contents in order to be consistent across distributed deployments
-
-        var cachedEtag = etags.get(cachekey);
-        if (cachedEtag) {
-            response.etag(cachedEtag, { vary: true });
-        }
-        else {
-            var hash = Crypto.createHash('sha1');
-            var processed = 0;
-            response.on('peek', function (chunk) {
-
-                hash.update(chunk);
-                processed += chunk.length;
-            });
-
-            response.once('finish', function () {
-
-                if (processed === stat.size) {
-                    var etag = hash.digest('hex');
-                    etags.set(cachekey, etag);
-                }
-            });
-        }
+    if (!etags) {
+        return callback();
     }
 
-    return callback();
+    // Use stat info for an LRU cache key.
+
+    var path = response.source.path;
+    var cachekey = [path, stat.ino, stat.size, stat.mtime.getTime()].join('-');
+
+    // The etag hashes the file contents in order to be consistent across distributed deployments
+
+    var cachedEtag = etags.get(cachekey);
+    if (cachedEtag) {
+        response.etag(cachedEtag, { vary: true });
+        return callback();
+    }
+
+    // Perform the hashing
+
+    var hash = Crypto.createHash('sha1');
+    hash.setEncoding('hex');
+
+    var fileStream = Fs.createReadStream(path, { fd: response.source.fd, autoClose: false });
+    fileStream.pipe(hash);
+
+    var done = function (err) {
+
+        if (err) {
+            return callback(Boom.wrap(err, null, 'Failed to hash file'));
+        }
+
+        var etag = hash.read();
+        etags.set(cachekey, etag);
+
+        response.etag(etag, { vary: true });
+
+        return callback();
+    };
+
+    done = Hoek.once(done);
+
+    fileStream.on('end', done);
+    fileStream.on('error', done);
 };
 
 
@@ -236,7 +250,7 @@ internals.openStream = function (response, path, next) {
 
     Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
 
-    var options = { fd: response.source.fd };
+    var options = { fd: response.source.fd, start: 0 };
 
     internals.addContentRange(response, function (err, range) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ exports.register = function (server, options, next) {
     var settings = Hoek.applyToDefaults(internals.defaults, options);
 
     server.expose('_etags', settings.etagsCacheMaxSize ? new Etag.Cache(settings.etagsCacheMaxSize) : null);
+    server.expose('_pendings', {});
 
     server.handler('file', File.handler);
     server.handler('directory', Directory.handler);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Directory = require('./directory');
+var Etag = require('./etag');
 var File = require('./file');
 var Hoek = require('hoek');
 
@@ -18,7 +19,7 @@ exports.register = function (server, options, next) {
 
     var settings = Hoek.applyToDefaults(internals.defaults, options);
 
-    server.expose('_etags', settings.etagsCacheMaxSize ? new File.Etags(settings.etagsCacheMaxSize) : null);
+    server.expose('_etags', settings.etagsCacheMaxSize ? new Etag.Cache(settings.etagsCacheMaxSize) : null);
 
     server.handler('file', File.handler);
     server.handler('directory', Directory.handler);

--- a/test/directory.js
+++ b/test/directory.js
@@ -770,6 +770,18 @@ describe('directory', function () {
             });
         });
 
+        it('respects the etagMethod option', function (done) {
+
+            var server = provisionServer();
+            server.route({ method: 'GET', path: '/{p*}', handler: { directory: { path: './file', etagMethod: 'simple' } } });
+
+            server.inject('/image.png', function (res) {
+
+                expect(res.headers.etag).to.match(/^".+-.+"$/);
+                done();
+            });
+        });
+
         it('returns a 403 when missing file read permission', function (done) {
 
             var filename = Hoek.uniqueFilename(Os.tmpDir());

--- a/test/file.js
+++ b/test/file.js
@@ -716,10 +716,13 @@ describe('file', function () {
 
             Items.parallel(['/file', '/file'], function (req, next) {
 
-                server.inject(req, function (res) {
+                setImmediate(function () {
 
-                    expect(res.statusCode).to.equal(500);
-                    next();
+                    server.inject(req, function (res) {
+
+                        expect(res.statusCode).to.equal(500);
+                        next();
+                    });
                 });
             }, done);
         });


### PR DESCRIPTION
This PR adds a new `etagMethod` option to the file and directory handlers, as suggested in #29:

 - `etagMethod` - specifies the method used to calculate the `ETag` header response. Available values:
   - `'hash'` - SHA1 sum of the file contents, suitable for distributed deployments. Default value.
   - `'simple'` - Hex encoded size and modification date, suitable when files are only stored on a single server.
   - `false` - Disable ETag computation.

Note that this changes the behavior of the default hashing method to always return an `ETag` header. This requires uncached etags to be computed in the prepare step, which translates to some extra latency in such requests, while the file is hashed. I don't believe that this should cause problems for most common use-cases and can actually improve performance in some cases (eg. cached `if-none-match` requests against a freshly started server can now serve a 304 response).