### PR TITLE
Avoid re-opening files when serving from a directory

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -46,12 +46,12 @@ exports.handler = function (route, options) {
 
 exports.load = function (path, request, options, callback) {
 
-    var response = exports.response(path, options, request);
+    var response = exports.response(path, options, request, true);
     return internals.prepare(response, callback);
 };
 
 
-exports.response = function (path, options, request) {
+exports.response = function (path, options, request, _preloaded) {
 
     options = options || {};
     Hoek.assert(!options.mode || ['attachment', 'inline'].indexOf(options.mode) !== -1, 'options.mode must be either false, attachment, or inline');
@@ -63,13 +63,13 @@ exports.response = function (path, options, request) {
         fd: null
     };
 
-    return request.generateResponse(source, { variety: 'file', marshal: internals.marshal, prepare: internals.prepare, close: internals.close });
+    var prepare = _preloaded ? null : internals.prepare;
+
+    return request.generateResponse(source, { variety: 'file', marshal: internals.marshal, prepare: prepare, close: internals.close });
 };
 
 
 internals.prepare = function (response, callback) {
-
-    internals.close(response);                  // Close any leftover descriptors from previous prepare call
 
     var path = response.source.path;
     internals.openStat(path, 'r', function (err, fd, stat) {

--- a/test/directory.js
+++ b/test/directory.js
@@ -832,5 +832,28 @@ describe('directory', function () {
                 done();
             });
         });
+
+        it('only stats the file system once when requesting a file', function (done) {
+
+            var orig = Fs.fstat;
+            var callCnt = 0;
+            Fs.fstat = function () {
+
+                callCnt++;
+                return orig.apply(Fs, arguments);
+            };
+
+            var server = provisionServer();
+            server.route({ method: 'GET', path: '/directory/{path*}', handler: { directory: { path: './' } } });
+
+            server.inject('/directory/directory.js', function (res) {
+
+                Fs.fstat = orig;
+                expect(callCnt).to.equal(1);
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.contain('hapi');
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
The file `prepare` phase is inadvertently called twice for the same file when served via the directory handler.

This patch fixes the issue by skipping the prepare phase once the response has been submitted. I have added an additional test to verify this behavior.

This issue is mostly a performance problem, though it can in extreme cases cause incorrect behavior if the file is moved / deleted between the two calls to the `prepare` function.