### PR TITLE
Added `defaultFilePath` option to directory handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,4 @@ object with the following options:
       - `false` - Disable ETag computation.
   - `defaultExtension` - optional string, appended to file requests if the requested file is
     not found. Defaults to no extension.
+  - `defaultFilePath` - optional string, which specifies the path of the file that should be served if the requested path does not exist. This is specially useful when serving web apps that use client side routing.

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -21,7 +21,8 @@ internals.schema = Joi.object({
     showHidden: Joi.boolean(),
     redirectToSlash: Joi.boolean(),
     lookupCompressed: Joi.boolean(),
-    defaultExtension: Joi.string().alphanum()
+    defaultExtension: Joi.string().alphanum(),
+    defaultFilePath: Joi.string()
 });
 
 
@@ -188,7 +189,26 @@ exports.handler = function (route, options) {
         },
         function (/* err */) {
 
-            return reply(Boom.notFound());
+            if (!settings.defaultFilePath) {
+
+                // Not found
+
+                return reply(Boom.notFound());
+
+            }
+
+            File.load(settings.defaultFilePath, request, { lookupCompressed: settings.lookupCompressed }, function (defaultResponse) {
+
+                // File loaded successfully
+
+                if (!defaultResponse.isBoom) {
+                    return reply(defaultResponse);
+                }
+
+                // Not found
+
+                return reply(Boom.notFound());
+            });
         });
     };
 

--- a/test/directory.js
+++ b/test/directory.js
@@ -867,5 +867,31 @@ describe('directory', function () {
                 done();
             });
         });
+
+        it('returns the specified default file when requesting a non existent subpath', function (done) {
+
+            var server = provisionServer();
+            server.route({ method: 'GET', path: '/directory/{path*}', handler: { directory: { path: './', defaultFilePath: 'directory/index.html' } } });
+
+            server.inject('/directory/directory/some-path', function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.contain('test');
+                done();
+            });
+        });
+
+        it('returns 404 if the specified default file does not exist when requesting a non existent subpath', function (done) {
+
+            var server = provisionServer();
+            server.route({ method: 'GET', path: '/directory/{path*}', handler: { directory: { path: './', defaultFilePath: 'directory/invalid.html' } } });
+
+            server.inject('/directory/directory/some-path', function (res) {
+
+                expect(res.statusCode).to.equal(404);
+                done();
+            });
+        });
+
     });
 });


### PR DESCRIPTION
Hey,

I'm using `inert` to serve web apps with client side routing and didn't find an easy way of specifying the default file to be served on sub paths.

I know I could use a global `onPreResponse` handler to check if the response was 404 and reply with the default file instead, but that also catches other REST endpoints that I don't want to modify.

Let me know what you think of this :)
