### PR TITLE
Restrict when range request logic is applied

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -148,22 +148,30 @@ internals.addContentRange = function (response, callback) {
         if (!request.headers['if-range'] ||
             request.headers['if-range'] === response.headers.etag) {            // Ignoring last-modified date (weak)
 
-            // Parse header
+            // Check that response is not encoded once transmitted
 
-            const ranges = Ammo.header(request.headers.range, length);
-            if (!ranges) {
-                const error = Boom.rangeNotSatisfiable();
-                error.output.headers['content-range'] = 'bytes */' + length;
-                return callback(error);
-            }
+            const mime = request.server.mime.type(response.headers['content-type'] || 'application/octet-stream');
+            const encoding = (request.connection.settings.compression && mime.compressible && !response.headers['content-encoding'] ? request.info.acceptEncoding : null);
 
-            // Prepare transform
+            if (encoding === 'identity' || !encoding) {
 
-            if (ranges.length === 1) {                                          // Ignore requests for multiple ranges
-                range = ranges[0];
-                response.code(206);
-                response.bytes(range.to - range.from + 1);
-                response.header('content-range', 'bytes ' + range.from + '-' + range.to + '/' + length);
+                // Parse header
+
+                const ranges = Ammo.header(request.headers.range, length);
+                if (!ranges) {
+                    const error = Boom.rangeNotSatisfiable();
+                    error.output.headers['content-range'] = 'bytes */' + length;
+                    return callback(error);
+                }
+
+                // Prepare transform
+
+                if (ranges.length === 1) {                                          // Ignore requests for multiple ranges
+                    range = ranges[0];
+                    response.code(206);
+                    response.bytes(range.to - range.from + 1);
+                    response.header('content-range', 'bytes ' + range.from + '-' + range.to + '/' + length);
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes issue #60 by serving plain `200` responses for compressed range requests.

The old implementation added regular `range` headers to responses that Hapi compresses during transmission, causing all kinds of weirdness.