### PR TITLE
Add TypeScript definition for `inert`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,1 @@
+export var inert: Object;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "4.0.3",
   "repository": "git://github.com/hapijs/inert",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "keywords": [
     "file",
     "directory",


### PR DESCRIPTION
Greetings,

This pull request fixes an issue with using inert and TypeScript in `noImplicitAny` mode.

The hapi.js library has a TypeScript definition registered over at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/types-2.0/hapi), but inert does not.  The original author included the extensions that inert adds to the reply object in the hapi.js definition itself (this may have been for historical reasons prior to inert's existence).  This causes a problem with TypeScript because it doesn't know what type `Inert` should have since there's not an official typing for it.  In an editor, if you're using TypeScript in a strict mode, you get this:

![inert - current behavior](https://cloud.githubusercontent.com/assets/3755379/21125921/eaf5c59a-c0b6-11e6-891e-791c9734c132.png)

TypeScript just wants to know what type `Inert` should have.  This Pull Request provides the typing for it - it's just `Object`.  This way, inert can be passed to server.register() with no complaints from TypeScript.  With this patch, the error goes away:

![inert - with patch behavior](https://cloud.githubusercontent.com/assets/3755379/21126061/18d7d48e-c0b8-11e6-8b64-2dc05cedcd5b.png)

I have implemented no changes to the inert behavior, all tests pass with 100% coverage.  The only difference is that once this is merged and published on npm it will be less annoying/confusing to get started with hapi.js/inert and TypeScript.

Thanks for creating hapi.js.