### PR TITLE
Manually extract last param name from path

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -33,6 +33,8 @@ exports.handler = function (route, options) {
     const settings = Joi.attempt(options, internals.schema, 'Invalid directory handler options (' + route.path + ')');
     Hoek.assert(route.path[route.path.length - 1] === '}', 'The route path for a directory handler must end with a parameter:', route.path);
 
+    const paramName = /\w+/.exec(route.path.slice(route.path.lastIndexOf('{')))[0];
+
     const normalize = (paths) => {
 
         const normalized = [];
@@ -77,7 +79,7 @@ exports.handler = function (route, options) {
 
         // Append parameter
 
-        const selection = request.paramsArray[request.paramsArray.length - 1];
+        const selection = request.params[paramName];
         if (selection &&
             !settings.showHidden &&
             internals.isFileHidden(selection)) {

--- a/test/directory.js
+++ b/test/directory.js
@@ -293,6 +293,19 @@ describe('directory', () => {
             });
         });
 
+        it('returns the "index.html" index file when route contains multiple path segments', (done) => {
+
+            const server = provisionServer();
+            server.route({ method: 'GET', path: '/directory{index}/{path*}', handler: { directory: { path: './directory/' } } });
+
+            server.inject('/directoryIndex/', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.contain('<p>test</p>');
+                done();
+            });
+        });
+
         it('returns the index file when found and single custom index file specified', (done) => {
 
             const server = provisionServer();


### PR DESCRIPTION
This fixes #74 by removing usage of `paramsArray`.
