### PR TITLE
include end option when create ReadStream

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -220,7 +220,7 @@ internals.openStream = function (response, path, next) {
 
     Hoek.assert(response.source.fd !== null, 'file descriptor must be set');
 
-    const options = { fd: response.source.fd, start: 0 };
+    const options = { fd: response.source.fd, start: 0 , end: response.headers['content-length'] };
 
     internals.addContentRange(response, (err, range) => {
 


### PR DESCRIPTION
include end option when create ReadStream to avoid node internal error when static file is inside Enigma Virtual Box.