### PR TITLE
Added customized directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,15 @@ object with the following options:
     the name(s) of the index file to look for. If `true`, looks for 'index.html'. Any falsy
     value disables index file lookup. Defaults to `true`.
   - `listing` - optional boolean, determines if directory listing is generated when a
-    directory is requested without an index document.
-    Defaults to `false`.
+    directory is requested without an index document. Defaults to `false`.
+    Value can be:
+      - a boolean
+      - a function with the signature `function(context, callback)` where context is an
+        object that provides:
+          - `location` - a `string` value of current location
+          - `parentPath` - a `string` value of parent directory, `null` if none
+          - `files` - an `array` of files in the current location
+        Callback must be called with `callback(err, renderedHtml)`
   - `showHidden` - optional boolean, determines if hidden files will be shown and served.
     Defaults to `false`.
   - `redirectToSlash` - optional boolean, determines if requests for a directory without a

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ object with the following options:
     if found in the folder when requesting a directory. The given string or strings specify
     the name(s) of the index file to look for. If `true`, looks for 'index.html'. Any falsy
     value disables index file lookup. Defaults to `true`.
-  - `listing` - optional boolean, determines if directory listing is generated when a
+  - `listing` - optional boolean|function, determines if directory listing is generated when a
     directory is requested without an index document. Defaults to `false`.
     Value can be:
-      - a boolean
+      - a boolean, if true a default html template will be used
       - a function with the signature `function(context, callback)`. Callback must be called
         with `callback(err, renderedHtml)`. Context is an object that provides:
           - `location` - a `string` value of current location

--- a/README.md
+++ b/README.md
@@ -240,12 +240,11 @@ object with the following options:
     directory is requested without an index document. Defaults to `false`.
     Value can be:
       - a boolean
-      - a function with the signature `function(context, callback)` where context is an
-        object that provides:
+      - a function with the signature `function(context, callback)`. Callback must be called
+        with `callback(err, renderedHtml)`. Context is an object that provides:
           - `location` - a `string` value of current location
           - `parentPath` - a `string` value of parent directory, `null` if none
           - `files` - an `array` of files in the current location
-        Callback must be called with `callback(err, renderedHtml)`
   - `showHidden` - optional boolean, determines if hidden files will be shown and served.
     Defaults to `false`.
   - `redirectToSlash` - optional boolean, determines if requests for a directory without a

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -19,7 +19,7 @@ const internals = {};
 internals.schema = Joi.object({
     path: Joi.alternatives(Joi.array().items(Joi.string()).single(), Joi.func()).required(),
     index: Joi.alternatives(Joi.boolean(), Joi.array().items(Joi.string()).single()).default(true),
-    listing: Joi.boolean(),
+    listing: Joi.alternatives(Joi.boolean(), Joi.func()),
     showHidden: Joi.boolean(),
     redirectToSlash: Joi.boolean(),
     lookupCompressed: Joi.boolean(),
@@ -211,7 +211,7 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
 
         resource = decodeURIComponent(resource);
         const display = Hoek.escapeHtml(resource);
-        let html = '<html><head><title>' + display + '</title></head><body><h1>Directory: ' + display + '</h1><ul>';
+        let html = '<body><h1>Directory: ' + display + '</h1><ul>';
 
         if (selection) {
             const parent = resource.substring(0, resource.lastIndexOf('/', resource.length - (hasTrailingSlash ? 2 : 1))) + '/';
@@ -226,9 +226,22 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
             }
         }
 
-        html = html + '</ul></body></html>';
+        if (typeof settings.listing === 'function') {
+            // convert to context object {resource, files}
 
-        return reply(request.generateResponse(html));
+            settings.listing(html, (err, template) => {
+
+                if (err) {
+                    return reply(Boom.internal('Error compiling listing', err));
+                }
+
+                reply(request.generateResponse(template));
+            });
+        }
+        else {
+            html = '<html><head><title>' + display + '</title></head>' + html + '</ul></body></html>';
+            return reply(request.generateResponse(html));
+        }
     });
 };
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -232,7 +232,10 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
 
         if (typeof settings.listing === 'function') {
 
-            const context = { resource, filesList };
+            const context = {
+                location: resource,
+                files: filesList
+            };
 
             settings.listing(context, (err, template) => {
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -212,10 +212,11 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
         resource = decodeURIComponent(resource);
         const display = Hoek.escapeHtml(resource);
         const filesList = [];
+        let parentPath = null;
 
         if (selection) {
             const parent = resource.substring(0, resource.lastIndexOf('/', resource.length - (hasTrailingSlash ? 2 : 1))) + '/';
-            filesList.push({ name: 'Parent Directory', path: internals.pathEncode(parent) });
+            parentPath = internals.pathEncode(parent);
         }
 
         for (let i = 0; i < files.length; ++i) {
@@ -233,6 +234,7 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
         if (typeof settings.listing === 'function') {
 
             const context = {
+                parentPath,
                 location: resource,
                 files: filesList
             };
@@ -249,6 +251,11 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
         else {
 
             let html = '<html><head><title>' + display + '</title></head><body><h1>Directory: ' + display + '</h1><ul>';
+
+            if (parentPath) {
+
+                html = html + '<li><a href="' + parentPath + '">Parent Directory</a></li>';
+            }
 
             for (let i = 0; i < filesList.length; ++i) {
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -211,25 +211,30 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
 
         resource = decodeURIComponent(resource);
         const display = Hoek.escapeHtml(resource);
-        let html = '<body><h1>Directory: ' + display + '</h1><ul>';
+        const filesList = [];
 
         if (selection) {
             const parent = resource.substring(0, resource.lastIndexOf('/', resource.length - (hasTrailingSlash ? 2 : 1))) + '/';
-            html = html + '<li><a href="' + internals.pathEncode(parent) + '">Parent Directory</a></li>';
+            filesList.push({ name: 'Parent Directory', path: internals.pathEncode(parent) });
         }
 
         for (let i = 0; i < files.length; ++i) {
             if (settings.showHidden ||
                 !internals.isFileHidden(files[i])) {
 
-                html = html + '<li><a href="' + internals.pathEncode(resource + (selection && !hasTrailingSlash ? '/' : '') + files[i]) + '">' + Hoek.escapeHtml(files[i]) + '</a></li>';
+                filesList.push({
+                    name: Hoek.escapeHtml(files[i]),
+                    path: internals.pathEncode(resource + (selection && !hasTrailingSlash ? '/' : '') + files[i])
+                });
+
             }
         }
 
         if (typeof settings.listing === 'function') {
-            // convert to context object {resource, files}
 
-            settings.listing(html, (err, template) => {
+            const context = { resource, filesList };
+
+            settings.listing(context, (err, template) => {
 
                 if (err) {
                     return reply(Boom.internal('Error compiling listing', err));
@@ -239,7 +244,14 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
             });
         }
         else {
-            html = '<html><head><title>' + display + '</title></head>' + html + '</ul></body></html>';
+
+            let html = '<html><head><title>' + display + '</title></head><body><h1>Directory: ' + display + '</h1><ul>';
+
+            for (let i = 0; i < filesList.length; ++i) {
+
+                html = html + '<li><a href="' + filesList[i].path + '">' + filesList[i].name + '</a></li>';
+            }
+            html = html + '</ul></body></html>';
             return reply(request.generateResponse(html));
         }
     });

--- a/test/directory.js
+++ b/test/directory.js
@@ -461,6 +461,61 @@ describe('directory', () => {
             });
         });
 
+        it('returns 500 when listing function returns error from callback', (done) => {
+
+            const listingFn = (context, callback) => {
+
+                callback(true, null);
+            };
+
+            const server = provisionServer();
+            server.route({ method: 'GET', path: '/listingfn/{path*}', handler: { directory: { path: './', listing: listingFn } } });
+
+            server.inject('/listingfn/', (res) => {
+
+                expect(res.statusCode).to.equal(500);
+                done();
+            });
+        });
+
+        it('returns listing html generated from context provided to listing function', (done) => {
+
+            const listingFn = (context, callback) => {
+
+                expect(context).to.have.include(['location', 'files']);
+                callback(null, '<html>' + context.location + '</html>');
+            };
+
+            const server = provisionServer();
+            server.route({ method: 'GET', path: '/listingfn/{path*}', handler: { directory: { path: './', listing: listingFn } } });
+
+            server.inject('/listingfn/', (res) => {
+
+                expect(res.payload).to.equal('<html>/listingfn/</html>');
+                expect(res.statusCode).to.equal(200);
+                done();
+            });
+        });
+
+        it('returns listing html provided from listing function', (done) => {
+
+            const listingFn = (context, callback) => {
+
+                expect(context).to.have.include(['location', 'files']);
+                callback(null, '<html>listing</html>');
+            };
+
+            const server = provisionServer();
+            server.route({ method: 'GET', path: '/listingfn/{path*}', handler: { directory: { path: './', listing: listingFn } } });
+
+            server.inject('/listingfn/', (res) => {
+
+                expect(res.payload).to.equal('<html>listing</html>');
+                expect(res.statusCode).to.equal(200);
+                done();
+            });
+        });
+
         it('returns a 404 response when requesting a hidden file when showHidden is disabled', (done) => {
 
             const server = provisionServer();

--- a/test/directory.js
+++ b/test/directory.js
@@ -482,7 +482,7 @@ describe('directory', () => {
 
             const listingFn = (context, callback) => {
 
-                expect(context).to.have.include(['location', 'files']);
+                expect(context).to.have.include(['parentPath', 'location', 'files']);
                 callback(null, '<html>' + context.location + '</html>');
             };
 
@@ -492,25 +492,6 @@ describe('directory', () => {
             server.inject('/listingfn/', (res) => {
 
                 expect(res.payload).to.equal('<html>/listingfn/</html>');
-                expect(res.statusCode).to.equal(200);
-                done();
-            });
-        });
-
-        it('returns listing html provided from listing function', (done) => {
-
-            const listingFn = (context, callback) => {
-
-                expect(context).to.have.include(['location', 'files']);
-                callback(null, '<html>listing</html>');
-            };
-
-            const server = provisionServer();
-            server.route({ method: 'GET', path: '/listingfn/{path*}', handler: { directory: { path: './', listing: listingFn } } });
-
-            server.inject('/listingfn/', (res) => {
-
-                expect(res.payload).to.equal('<html>listing</html>');
                 expect(res.statusCode).to.equal(200);
                 done();
             });


### PR DESCRIPTION
Followed spec by OP in #31 for the most part. 

I figure additional support for vision can be added later with a different value passed to listing.

I was also tempted to expose more data in the context such as a `raw` field per file item that provides the absolute path on the filesystem. That way you could stat the file and sort and categorize the files any way a user wants to instead of just alphabetically as it is right now. However, I'm unsure of what security concerns there may be. 

Let me know if I should add that.