### PR TITLE
Limit "node" tests to only try configured hapi release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ env:
     - HAPI_VERSION="@15"
     - HAPI_VERSION=""
 
+matrix:
+  exclude:
+  - node_js: "node"
+    env: HAPI_VERSION="@13"
+  - node_js: "node"
+    env: HAPI_VERSION="@14"
+  - node_js: "node"
+    env: HAPI_VERSION="@15"
+
 install:
     - npm install
     - npm install hapi$HAPI_VERSION


### PR DESCRIPTION
Node 8 breaks tests relying on old versions of Hapi. This add exclusions to the tests matrix for the failing (and unsupported) combinations.