### PR TITLE
Internal rewrite to async / await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
   - "8"
   - "node"
 
@@ -10,21 +8,6 @@ sudo: false
 
 env:
     - HAPI_VERSION=""
-
-matrix:
-  include:
-  - node_js: "4"
-    env: HAPI_VERSION="@13"
-  - node_js: "4"
-    env: HAPI_VERSION="@14"
-  - node_js: "4"
-    env: HAPI_VERSION="@15"
-  - node_js: "6"
-    env: HAPI_VERSION="@13"
-  - node_js: "6"
-    env: HAPI_VERSION="@14"
-  - node_js: "6"
-    env: HAPI_VERSION="@15"
 
 install:
     - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,7 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "4"
-    - nodejs_version: "6"
+    - nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -99,23 +99,23 @@ exports.handler = function (route, options) {
             etagMethod: settings.etagMethod
         };
 
-        Items.serial(paths, (baseDir, nextPath) => {
+        Items.serial(paths, async (baseDir, nextPath) => {
 
             fileOptions.confine = baseDir;
 
             let path = selection || '';
 
-            File.load(path, request, fileOptions, (response) => {
+            try {
+                const response = await File.load(path, request, fileOptions);
 
                 // File loaded successfully
 
-                if (!response.isBoom) {
-                    return reply(response);
-                }
+                return reply(response);
+            }
+            catch (err) {
 
                 // Not found
 
-                const err = response;
                 if (err.output.statusCode === 404) {
                     if (!settings.defaultExtension) {
                         return nextPath();
@@ -125,14 +125,13 @@ exports.handler = function (route, options) {
                         path = path.slice(0, -1);
                     }
 
-                    return File.load(path + '.' + settings.defaultExtension, request, fileOptions, (extResponse) => {
-
-                        if (!extResponse.isBoom) {
-                            return reply(extResponse);
-                        }
-
+                    try {
+                        const extResponse = await File.load(path + '.' + settings.defaultExtension, request, fileOptions);
+                        return reply(extResponse);
+                    }
+                    catch (err) {
                         return nextPath();
-                    });
+                    }
                 }
 
                 // Propagate non-directory errors
@@ -156,20 +155,20 @@ exports.handler = function (route, options) {
                     return reply.redirect(resource + '/');
                 }
 
-                Items.serial(indexNames, (indexName, nextIndex) => {
+                Items.serial(indexNames, async (indexName, nextIndex) => {
 
                     const indexFile = Path.join(path, indexName);
-                    File.load(indexFile, request, fileOptions, (indexResponse) => {
+                    try {
+                        const indexResponse = await File.load(indexFile, request, fileOptions);
 
                         // File loaded successfully
 
-                        if (!indexResponse.isBoom) {
-                            return reply(indexResponse);
-                        }
+                        return reply(indexResponse);
+                    }
+                    catch (err) {
 
                         // Directory
 
-                        const err = indexResponse;
                         if (err.output.statusCode !== 404) {
                             return reply(Boom.badImplementation(indexName + ' is a directory'));
                         }
@@ -177,7 +176,7 @@ exports.handler = function (route, options) {
                         // Not found, try the next one
 
                         return nextIndex();
-                    });
+                    }
                 },
                 (/* err */) => {
 
@@ -189,7 +188,7 @@ exports.handler = function (route, options) {
 
                     return internals.generateListing(Path.join(baseDir, path), resource, selection, hasTrailingSlash, settings, request, reply);
                 });
-            });
+            }
         },
         (/* err */) => {
 
@@ -201,35 +200,36 @@ exports.handler = function (route, options) {
 };
 
 
-internals.generateListing = function (path, resource, selection, hasTrailingSlash, settings, request, reply) {
+internals.generateListing = async function (path, resource, selection, hasTrailingSlash, settings, request, reply) {
 
-    Fs.readdir(path, (err, files) => {
+    let files;
+    try {
+        files = await Fs.readdir(path);
+    }
+    catch (err) {
+        return reply(Boom.internal('Error accessing directory', err));
+    }
 
-        if (err) {
-            return reply(Boom.internal('Error accessing directory', err));
+    resource = decodeURIComponent(resource);
+    const display = Hoek.escapeHtml(resource);
+    let html = '<html><head><title>' + display + '</title></head><body><h1>Directory: ' + display + '</h1><ul>';
+
+    if (selection) {
+        const parent = resource.substring(0, resource.lastIndexOf('/', resource.length - (hasTrailingSlash ? 2 : 1))) + '/';
+        html = html + '<li><a href="' + internals.pathEncode(parent) + '">Parent Directory</a></li>';
+    }
+
+    for (let i = 0; i < files.length; ++i) {
+        if (settings.showHidden ||
+            !internals.isFileHidden(files[i])) {
+
+            html = html + '<li><a href="' + internals.pathEncode(resource + (selection && !hasTrailingSlash ? '/' : '') + files[i]) + '">' + Hoek.escapeHtml(files[i]) + '</a></li>';
         }
+    }
 
-        resource = decodeURIComponent(resource);
-        const display = Hoek.escapeHtml(resource);
-        let html = '<html><head><title>' + display + '</title></head><body><h1>Directory: ' + display + '</h1><ul>';
+    html = html + '</ul></body></html>';
 
-        if (selection) {
-            const parent = resource.substring(0, resource.lastIndexOf('/', resource.length - (hasTrailingSlash ? 2 : 1))) + '/';
-            html = html + '<li><a href="' + internals.pathEncode(parent) + '">Parent Directory</a></li>';
-        }
-
-        for (let i = 0; i < files.length; ++i) {
-            if (settings.showHidden ||
-                !internals.isFileHidden(files[i])) {
-
-                html = html + '<li><a href="' + internals.pathEncode(resource + (selection && !hasTrailingSlash ? '/' : '') + files[i]) + '">' + Hoek.escapeHtml(files[i]) + '</a></li>';
-            }
-        }
-
-        html = html + '</ul></body></html>';
-
-        return reply(request.generateResponse(html));
-    });
+    return reply(request.generateResponse(html));
 };
 
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -2,13 +2,13 @@
 
 // Load modules
 
-const Fs = require('fs');
 const Path = require('path');
 const Boom = require('boom');
 const Hoek = require('hoek');
 const Items = require('items');
 const Joi = require('joi');
 const File = require('./file');
+const Fs = require('./fs');
 
 
 // Declare internals

--- a/lib/etag.js
+++ b/lib/etag.js
@@ -4,7 +4,6 @@
 
 const Crypto = require('crypto');
 const Boom = require('boom');
-const Hoek = require('hoek');
 const LruCache = require('lru-cache');
 
 
@@ -15,11 +14,21 @@ const internals = {
 };
 
 
-internals.computeHashed = function (response, stat, next) {
+internals.streamEnd = function (stream) {
+
+    return new Promise((resolve, reject) => {
+
+        stream.on('end', resolve);
+        stream.on('error', reject);
+    });
+};
+
+
+internals.computeHashed = async function (response, stat) {
 
     const etags = response.request.server.plugins.inert._etags;
     if (!etags) {
-        return next(null, null);
+        return null;
     }
 
     // Use stat info for an LRU cache key.
@@ -31,36 +40,36 @@ internals.computeHashed = function (response, stat, next) {
 
     const cachedEtag = etags.get(cachekey);
     if (cachedEtag) {
-        return next(null, cachedEtag);
+        return cachedEtag;
     }
 
-    let nexts = internals.pendings[cachekey];
-    if (nexts) {
-        return nexts.push(next);
+    let promise = internals.pendings[cachekey];
+    if (promise) {
+        return await promise;
     }
 
     // Start hashing
 
-    nexts = [next];
-    internals.pendings[cachekey] = nexts;
+    const compute = async () => {
 
-    internals.hashFile(response, (err, hash) => {
-
-        if (!err) {
+        try {
+            const hash = await internals.hashFile(response);
             etags.set(cachekey, hash);
-        }
 
-        // Call pending callbacks
-
-        delete internals.pendings[cachekey];
-        for (let i = 0; i < nexts.length; ++i) {
-            Hoek.nextTick(nexts[i])(err, hash);
+            return hash;
         }
-    });
+        finally {
+            delete internals.pendings[cachekey];
+        }
+    };
+
+    internals.pendings[cachekey] = promise = compute();
+
+    return await promise;
 };
 
 
-internals.hashFile = function (response, callback) {
+internals.hashFile = async function (response) {
 
     const hash = Crypto.createHash('sha1');
     hash.setEncoding('hex');
@@ -68,56 +77,43 @@ internals.hashFile = function (response, callback) {
     const fileStream = response.source.file.createReadStream({ autoClose: false });
     fileStream.pipe(hash);
 
-    let done = function (err) {
-
-        if (err) {
-            return callback(Boom.boomify(err, { message: 'Failed to hash file' }));
-        }
-
-        return callback(null, hash.read());
-    };
-
-    done = Hoek.once(done);
-
-    fileStream.on('end', done);
-    fileStream.on('error', done);
+    try {
+        await internals.streamEnd(fileStream);
+        return hash.read();
+    }
+    catch (err) {
+        throw Boom.boomify(err, { message: 'Failed to hash file' });
+    }
 };
 
 
-internals.computeSimple = function (response, stat, next) {
+internals.computeSimple = function (response, stat) {
 
     const size = stat.size.toString(16);
     const mtime = stat.mtime.getTime().toString(16);
 
-    return next(null, size + '-' + mtime);
+    return size + '-' + mtime;
 };
 
 
-exports.apply = function (response, stat, next) {
+exports.apply = async function (response, stat) {
 
     const etagMethod = response.source.settings.etagMethod;
     if (etagMethod === false) {
-        return next();
+        return;
     }
 
-    const applyEtag = (err, etag) => {
-
-        if (err) {
-            return next(err);
-        }
-
-        if (etag !== null) {
-            response.etag(etag, { vary: true });
-        }
-
-        return next();
-    };
-
+    let etag;
     if (etagMethod === 'simple') {
-        return internals.computeSimple(response, stat, applyEtag);
+        etag = internals.computeSimple(response, stat);
+    }
+    else {
+        etag = await internals.computeHashed(response, stat);
     }
 
-    return internals.computeHashed(response, stat, applyEtag);
+    if (etag !== null) {
+        response.etag(etag, { vary: true });
+    }
 };
 
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -56,10 +56,10 @@ exports.handler = function (route, options) {
 };
 
 
-exports.load = function (path, request, options, callback) {
+exports.load = async function (path, request, options) {
 
     const response = exports.response(path, options, request, true);
-    return internals.prepare(response, callback);
+    return internals._prepare(response);
 };
 
 
@@ -93,24 +93,24 @@ exports.response = function (path, options, request, _preloaded) {
 };
 
 
-internals.prepare = function (response, callback) {
+internals.prepare = function (response, next) {
+
+    internals._prepare(response).then(next, next);
+};
+
+
+internals._prepare = async function (response) {
 
     const path = response.source.path;
 
     if (path === null) {
-        return process.nextTick(() => {
-
-            return callback(Boom.forbidden(null, 'EACCES'));
-        });
+        throw Boom.forbidden(null, 'EACCES');
     }
 
     const file = response.source.file = new Fs.File(path);
 
-    file.openStat('r', (err, stat) => {
-
-        if (err) {
-            return callback(err);
-        }
+    try {
+        const stat = await file.openStat('r');
 
         const start = response.source.settings.start || 0;
         if (response.source.settings.end !== undefined) {
@@ -131,20 +131,25 @@ internals.prepare = function (response, callback) {
             response.header('content-disposition', response.source.settings.mode + '; filename=' + encodeURIComponent(fileName));
         }
 
-        Etag.apply(response, stat, (err) => {
+        await Etag.apply(response, stat);
 
-            if (err) {
-                internals.close(response);
-                return callback(err);
-            }
+        return response;
+    }
+    catch (err) {
 
-            return callback(response);
-        });
-    });
+        internals.close(response);
+        throw err;
+    }
 };
 
 
 internals.marshal = function (response, next) {
+
+    internals._marshal(response).then(next.bind(undefined, null), next);
+};
+
+
+internals._marshal = async function (response) {
 
     if (response.source.settings.lookupCompressed &&
         !response.source.settings.start &&
@@ -156,33 +161,36 @@ internals.marshal = function (response, next) {
         const extension = lookupMap.hasOwnProperty(encoding) ? lookupMap[encoding] : null;
         if (extension) {
             const gzFile = new Fs.File(`${response.source.path}${extension}`);
-            return gzFile.openStat('r', (err, stat) => {
+            let stat;
+            try {
+                stat = await gzFile.openStat('r');
+            }
+            catch (err) {
+                gzFile.close();
+            }
 
-                if (!err) {
-                    response.source.file.close();
-                    response.source.file = gzFile;
+            if (stat) {
+                response.source.file.close();
+                response.source.file = gzFile;
 
-                    response.bytes(stat.size);
-                    response.header('content-encoding', encoding);
-                    response.vary('accept-encoding');
-                }
-
-                return internals.createStream(response, next);
-            });
+                response.bytes(stat.size);
+                response.header('content-encoding', encoding);
+                response.vary('accept-encoding');
+            }
         }
     }
 
-    return internals.createStream(response, next);
+    return internals.createStream(response);
 };
 
 
-internals.addContentRange = function (response, next) {
+internals.addContentRange = function (response) {
 
     const request = response.request;
     const length = response.headers['content-length'];
     let range = null;
 
-    if (Hoek.reach(request.route.settings, 'response.ranges') !== false) {     // Backwards compatible comparison
+    if (request.route.settings.response.ranges) {
         if (request.headers.range && length) {
 
             // Check If-Range
@@ -203,7 +211,7 @@ internals.addContentRange = function (response, next) {
                     if (!ranges) {
                         const error = Boom.rangeNotSatisfiable();
                         error.output.headers['content-range'] = 'bytes */' + length;
-                        return next(error);
+                        throw error;
                     }
 
                     // Prepare transform
@@ -221,34 +229,29 @@ internals.addContentRange = function (response, next) {
         response.header('accept-ranges', 'bytes');
     }
 
-    return next(null, range);
+    return range;
 };
 
 
-internals.createStream = function (response, next) {
+internals.createStream = function (response) {
 
     const source = response.source;
 
     Hoek.assert(source.file !== null);
 
-    internals.addContentRange(response, (err, range) => {
+    const range = internals.addContentRange(response);
 
-        if (err) {
-            return next(err);
-        }
+    const options = {
+        start: source.settings.start || 0,
+        end: source.settings.end
+    };
 
-        const options = {
-            start: source.settings.start || 0,
-            end: source.settings.end
-        };
+    if (range) {
+        options.end = range.to + options.start;
+        options.start = range.from + options.start;
+    }
 
-        if (range) {
-            options.end = range.to + options.start;
-            options.start = range.from + options.start;
-        }
-
-        return next(null, source.file.createReadStream(options));
-    });
+    return source.file.createReadStream(options);
 };
 
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -4,12 +4,16 @@
 
 const Boom = require('boom');
 const Hoek = require('hoek');
+const Util = require('util');
 
 
 // Declare internals
 
 const internals = {
-    methods: ['open', 'close', 'fstat', 'createReadStream', 'readdir']
+    methods: {
+        promised: ['open', 'close', 'fstat', 'readdir'],
+        raw: ['createReadStream']
+    }
 };
 
 
@@ -20,71 +24,60 @@ exports.File = function (path) {
 };
 
 
-exports.File.prototype.open = function (mode, callback) {
+exports.File.prototype.open = async function (mode) {
 
     Hoek.assert(this.fd === null);
 
-    exports.open(this.path, mode, (err, fd) => {
-
-        if (err) {
-            if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT') {
-                return callback(Boom.notFound());
-            }
-
-            if (err.code === 'EACCES' || err.code === 'EPERM') {
-                return callback(Boom.forbidden(null, err.code));
-            }
-
-            return callback(Boom.boomify(err, { message: 'Failed to open file' }));
+    try {
+        this.fd = await exports.open(this.path, mode);
+    }
+    catch (err) {
+        if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT') {
+            throw Boom.notFound();
         }
 
-        this.fd = fd;
+        if (err.code === 'EACCES' || err.code === 'EPERM') {
+            throw Boom.forbidden(null, err.code);
+        }
 
-        return callback();
-    });
+        throw Boom.boomify(err, { message: 'Failed to open file' });
+    }
 };
 
 
 exports.File.prototype.close = function () {
 
     if (this.fd !== null) {
-        exports.close(this.fd, Hoek.ignore);
+        exports.close(this.fd).then(null, Hoek.ignore);
         this.fd = null;
     }
 };
 
 
-exports.File.prototype.stat = function (callback) {
+exports.File.prototype.stat = async function () {
 
     Hoek.assert(this.fd !== null);
 
-    exports.fstat(this.fd, (err, stat) => {
-
-        if (err) {
-            this.close(this.fd);
-            return callback(Boom.boomify(err, { message: 'Failed to stat file' }));
-        }
+    try {
+        const stat = await exports.fstat(this.fd);
 
         if (stat.isDirectory()) {
-            this.close(this.fd);
-            return callback(Boom.forbidden(null, 'EISDIR'));
+            throw Boom.forbidden(null, 'EISDIR');
         }
 
-        return callback(null, stat);
-    });
+        return stat;
+    }
+    catch (err) {
+        this.close(this.fd);
+        throw err.isBoom ? err : Boom.boomify(err, { message: 'Failed to stat file' });
+    }
 };
 
 
-exports.File.prototype.openStat = function (mode, callback) {
+exports.File.prototype.openStat = async function (mode) {
 
-    this.open(mode, (err) => {
-
-        if (err) {
-            return callback(err);
-        }
-
-        this.stat(callback);
-    });
+    await this.open(mode);
+    return this.stat();
 };
 
 
@@ -104,9 +97,14 @@ exports.File.prototype.createReadStream = function (options) {
 };
 
 
-// Export raw Fs methods
+// Export Fs methods
 
 const NodeFs = require('fs');
-for (let i = 0; i < internals.methods.length; ++i) {
-    exports[internals.methods[i]] = NodeFs[internals.methods[i]].bind(NodeFs);
+for (let i = 0; i < internals.methods.raw.length; ++i) {
+    const method = internals.methods.raw[i];
+    exports[method] = NodeFs[method].bind(NodeFs);
+}
+for (let i = 0; i < internals.methods.promised.length; ++i) {
+    const method = internals.methods.promised[i];
+    exports[method] = Util.promisify(NodeFs[method]);
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2,14 +2,15 @@
 
 // Load modules
 
-const Fs = require('fs');
 const Boom = require('boom');
 const Hoek = require('hoek');
 
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    methods: ['open', 'close', 'fstat', 'createReadStream', 'readdir']
+};
 
 
 exports.File = function (path) {
@@ -23,7 +24,7 @@ exports.File.prototype.open = function (mode, callback) {
 
     Hoek.assert(this.fd === null);
 
-    Fs.open(this.path, mode, (err, fd) => {
+    exports.open(this.path, mode, (err, fd) => {
 
         if (err) {
             if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT') {
@@ -47,7 +48,7 @@ exports.File.prototype.open = function (mode, callback) {
 exports.File.prototype.close = function () {
 
     if (this.fd !== null) {
-        Fs.close(this.fd, Hoek.ignore);
+        exports.close(this.fd, Hoek.ignore);
         this.fd = null;
     }
 };
@@ -57,7 +58,7 @@ exports.File.prototype.stat = function (callback) {
 
     Hoek.assert(this.fd !== null);
 
-    Fs.fstat(this.fd, (err, stat) => {
+    exports.fstat(this.fd, (err, stat) => {
 
         if (err) {
             this.close(this.fd);
@@ -93,7 +94,7 @@ exports.File.prototype.createReadStream = function (options) {
 
     options = Object.assign({ fd: this.fd, start: 0 }, options);
 
-    const stream = Fs.createReadStream(this.path, options);
+    const stream = exports.createReadStream(this.path, options);
 
     if (options.autoClose !== false) {
         this.fd = null;           // The stream now owns the fd
@@ -101,3 +102,11 @@ exports.File.prototype.createReadStream = function (options) {
 
     return stream;
 };
+
+
+// Export raw Fs methods
+
+const NodeFs = require('fs');
+for (let i = 0; i < internals.methods.length; ++i) {
+    exports[internals.methods[i]] = NodeFs[internals.methods[i]].bind(NodeFs);
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "plugin"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "ammo": "2.x.x",
@@ -23,7 +23,7 @@
     "lru-cache": "4.1.x"
   },
   "devDependencies": {
-    "code": "4.x.x",
+    "code": "5.x.x",
     "hapi": "16.x.x",
     "lab": "14.x.x"
   },

--- a/test/directory.js
+++ b/test/directory.js
@@ -10,6 +10,7 @@ const Code = require('code');
 const Hapi = require('hapi');
 const Hoek = require('hoek');
 const Inert = require('..');
+const InertFs = require('../lib/fs');
 const Lab = require('lab');
 
 
@@ -608,10 +609,10 @@ describe('directory', () => {
             const server = provisionServer();
             server.route({ method: 'GET', path: '/directorylist/{path*}', handler: { directory: { path: '../', listing: true } } });
 
-            const orig = Fs.readdir;
-            Fs.readdir = (path, callback) => {
+            const orig = InertFs.readdir;
+            InertFs.readdir = (path, callback) => {
 
-                Fs.readdir = orig;
+                InertFs.readdir = orig;
                 return callback(new Error('Simulated Directory Error'));
             };
 
@@ -838,10 +839,10 @@ describe('directory', () => {
 
         it('returns error when a file open fails', (done) => {
 
-            const orig = Fs.open;
-            Fs.open = function () {        // can return EMFILE error
+            const orig = InertFs.open;
+            InertFs.open = function () {        // can return EMFILE error
 
-                Fs.open = orig;
+                InertFs.open = orig;
                 const callback = arguments[arguments.length - 1];
                 callback(new Error('failed'));
             };
@@ -870,12 +871,12 @@ describe('directory', () => {
 
         it('only stats the file system once when requesting a file', (done) => {
 
-            const orig = Fs.fstat;
+            const orig = InertFs.fstat;
             let callCnt = 0;
-            Fs.fstat = function () {
+            InertFs.fstat = function () {
 
                 callCnt++;
-                return orig.apply(Fs, arguments);
+                return orig.apply(InertFs, arguments);
             };
 
             const server = provisionServer();

--- a/test/file.js
+++ b/test/file.js
@@ -12,6 +12,7 @@ const Hapi = require('hapi');
 const Hoek = require('hoek');
 const Items = require('items');
 const Inert = require('..');
+const InertFs = require('../lib/fs');
 const Lab = require('lab');
 
 
@@ -733,17 +734,17 @@ describe('file', () => {
 
             // Prepare complicated mocking setup to fake an io error
 
-            const orig = Fs.createReadStream;
-            Fs.createReadStream = function (path, options) {
+            const orig = InertFs.createReadStream;
+            InertFs.createReadStream = function (path, options) {
 
-                Fs.createReadStream = orig;
+                InertFs.createReadStream = orig;
 
                 process.nextTick(() => {
 
                     Fs.closeSync(options.fd);
                 });
 
-                return Fs.createReadStream(path, options);
+                return InertFs.createReadStream(path, options);
             };
 
             server.inject('/file', (res) => {
@@ -760,17 +761,17 @@ describe('file', () => {
 
             // Prepare complicated mocking setup to fake an io error
 
-            const orig = Fs.createReadStream;
-            Fs.createReadStream = function (path, options) {
+            const orig = InertFs.createReadStream;
+            InertFs.createReadStream = function (path, options) {
 
-                Fs.createReadStream = orig;
+                InertFs.createReadStream = orig;
 
                 process.nextTick(() => {
 
                     Fs.closeSync(options.fd);
                 });
 
-                return Fs.createReadStream(path, options);
+                return InertFs.createReadStream(path, options);
             };
 
             Items.parallel(['/file', '/file'], (req, next) => {
@@ -1222,10 +1223,10 @@ describe('file', () => {
             const filename = Hoek.uniqueFilename(Os.tmpdir()) + '.package.json';
             Fs.writeFileSync(filename, 'data');
 
-            const orig = Fs.fstat;
-            Fs.fstat = function (fd, callback) {        // can return EIO error
+            const orig = InertFs.fstat;
+            InertFs.fstat = function (fd, callback) {        // can return EIO error
 
-                Fs.fstat = orig;
+                InertFs.fstat = orig;
                 callback(new Error('failed'));
             };
 
@@ -1245,10 +1246,10 @@ describe('file', () => {
             const filename = Hoek.uniqueFilename(Os.tmpdir()) + '.package.json';
             Fs.writeFileSync(filename, 'data');
 
-            const orig = Fs.open;
-            Fs.open = function () {        // can return EMFILE error
+            const orig = InertFs.open;
+            InertFs.open = function () {        // can return EMFILE error
 
-                Fs.open = orig;
+                InertFs.open = orig;
                 const callback = arguments[arguments.length - 1];
                 callback(new Error('failed'));
             };
@@ -1285,13 +1286,13 @@ describe('file', () => {
             let didOpen = false;
             server.inject('/', (res1) => {
 
-                const orig = Fs.open;
-                Fs.open = function (path, mode, callback) {        // fake alternate permission error
+                const orig = InertFs.open;
+                InertFs.open = function (path, mode, callback) {        // fake alternate permission error
 
-                    Fs.open = orig;
+                    InertFs.open = orig;
                     didOpen = true;
 
-                    return Fs.open(path, mode, (err, fd) => {
+                    return InertFs.open(path, mode, (err, fd) => {
 
                         if (err) {
                             if (err.code === 'EACCES') {
@@ -1512,13 +1513,13 @@ describe('file', () => {
                 // Catch createReadStream options
 
                 let createOptions;
-                const orig = Fs.createReadStream;
-                Fs.createReadStream = function (path, options) {
+                const orig = InertFs.createReadStream;
+                InertFs.createReadStream = function (path, options) {
 
-                    Fs.createReadStream = orig;
+                    InertFs.createReadStream = orig;
                     createOptions = options;
 
-                    return Fs.createReadStream(path, options);
+                    return InertFs.createReadStream(path, options);
                 };
 
                 server.inject({ url: '/file', headers: { 'range': 'bytes=1-4', 'accept-encoding': 'gzip' } }, (res) => {


### PR DESCRIPTION
All internal logic has been rewritten to use `async` / `await`.

It is still targets hapi@16 for the interface, but should be simple to update. To fully target v17, all tests needs to be rewritten.