### PR TITLE
Add ability to add headers to file responses

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -36,7 +36,8 @@ internals.schema = Joi.alternatives([
         lookupMap: Joi.object().min(1).pattern(/.+/, Joi.string()),
         etagMethod: Joi.string().valid('hash', 'simple').allow(false),
         start: Joi.number().integer().min(0).default(0),
-        end: Joi.number().integer().min(Joi.ref('start'))
+        end: Joi.number().integer().min(Joi.ref('start')),
+        additionalHeaders: Joi.object()
     })
         .with('filename', 'mode')
 ]);
@@ -105,6 +106,16 @@ internals.prepare = async function (response) {
     }
 
     const file = response.source.file = new Fs.File(path);
+
+    const { additionalHeaders } = response.source.settings;
+
+    if (additionalHeaders) {
+        const keys = Object.keys(additionalHeaders);
+        for (let i = 0; i < keys.length; ++i) {
+            const key = keys[i];
+            response.header(key, additionalHeaders[key]);
+        }
+    }
 
     try {
         const stat = await file.openStat('r');

--- a/test/file.js
+++ b/test/file.js
@@ -1491,5 +1491,23 @@ describe('file', () => {
                 cmd.stdin.end();
             });
         });
+
+        it('returns a custom headers to file handler responses', async () => {
+
+            const server = await provisionServer();
+            server.route({
+                method: 'GET',
+                path: '/file',
+                handler: {
+                    file: {
+                        path: Path.join(__dirname, 'file/image.png'),
+                        additionalHeaders: { 'custom-header': 'value' }
+                    }
+                }
+            });
+
+            const res = await server.inject('/file');
+            expect(res.headers['custom-header']).to.equal('value');
+        });
     });
 });


### PR DESCRIPTION
[Implements #83](https://github.com/hapijs/inert/issues/83)
Example
``` javascript
server.route({
                method: 'GET',
                path: '/file',
                handler: {
                    file: {
                        path: Path.join(__dirname, 'file/image.png'),
                        additionalHeaders: { 'custom-header': 'value' }
                    }
                }
            });
```