### PR TITLE
Added custom headers to file and directory handler responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Generates a static file endpoint for serving a single file. `file` can be set to
           - `false` - Disable ETag computation.
       - `start` - offset in file to reading from, defaults to 0.
       - `end` - offset in file to stop reading from. If not set, will read to end of file.
-
+      - `additionalHeaders` - an `object` which specifies the additional response headers.
 ### The `directory` handler
 
 Generates a directory endpoint for serving static content from a directory.
@@ -259,7 +259,7 @@ object with the following options:
       - `false` - Disable ETag computation.
   - `defaultExtension` - optional string, appended to file requests if the requested file is
     not found. Defaults to no extension.
-
+  - `additionalHeaders` - optional object which specifies the additional response headers.
 ### Errors
 
 Any file access errors are signalled using appropriate [Boom](https://github.com/hapijs/boom)

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -27,7 +27,8 @@ internals.schema = Joi.object({
     lookupCompressed: Joi.boolean(),
     lookupMap: Joi.object().min(1).pattern(/.+/, Joi.string()),
     etagMethod: Joi.string().valid('hash', 'simple').allow(false),
-    defaultExtension: Joi.string().alphanum()
+    defaultExtension: Joi.string().alphanum(),
+    additionalHeaders: Joi.object()
 });
 
 
@@ -95,7 +96,8 @@ exports.handler = function (route, options) {
             confine: null,
             lookupCompressed: settings.lookupCompressed,
             lookupMap: settings.lookupMap,
-            etagMethod: settings.etagMethod
+            etagMethod: settings.etagMethod,
+            additionalHeaders: settings.additionalHeaders
         };
 
         const each = async (baseDir) => {
@@ -130,6 +132,7 @@ exports.handler = function (route, options) {
             // Handle Directory
 
             if (internals.isDirectory(error)) {
+
                 if (settings.redirectToSlash !== false &&                       // Defaults to true
                     !request.server.settings.router.stripTrailingSlash &&
                     !hasTrailingSlash) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -36,7 +36,8 @@ internals.schema = Joi.alternatives([
         lookupMap: Joi.object().min(1).pattern(/.+/, Joi.string()),
         etagMethod: Joi.string().valid('hash', 'simple').allow(false),
         start: Joi.number().integer().min(0).default(0),
-        end: Joi.number().integer().min(Joi.ref('start'))
+        end: Joi.number().integer().min(Joi.ref('start')),
+        additionalHeaders: Joi.object()
     })
         .with('filename', 'mode')
 ]);
@@ -105,6 +106,16 @@ internals.prepare = async function (response) {
     }
 
     const file = response.source.file = new Fs.File(path);
+
+    const { additionalHeaders } = response.source.settings;
+
+    if (additionalHeaders) {
+        const keys = Object.keys(additionalHeaders);
+        for (let i = 0; i < keys.length; ++i) {
+            const key = keys[i];
+            response.header(key, additionalHeaders[key]);
+        }
+    }
 
     try {
         const stat = await file.openStat('r');

--- a/test/directory.js
+++ b/test/directory.js
@@ -752,5 +752,23 @@ describe('directory', () => {
             expect(res.statusCode).to.equal(200);
             expect(res.payload).to.contain('hapi');
         });
+
+        it('returns a custom headers to directory handler responses', async () => {
+
+            const server = await provisionServer();
+            server.route({
+                method: 'GET',
+                path: '/{path*}',
+                handler: {
+                    directory: {
+                        path: Path.join(__dirname, './directory/'),
+                        additionalHeaders: { 'custom-header': 'value' }
+                    }
+                }
+            });
+
+            const res = await server.inject('/index.html');
+            expect(res.headers['custom-header']).to.equal('value');
+        });
     });
 });

--- a/test/file.js
+++ b/test/file.js
@@ -1491,5 +1491,23 @@ describe('file', () => {
                 cmd.stdin.end();
             });
         });
+
+        it('returns a custom headers to file handler responses', async () => {
+
+            const server = await provisionServer();
+            server.route({
+                method: 'GET',
+                path: '/file',
+                handler: {
+                    file: {
+                        path: Path.join(__dirname, 'file/image.png'),
+                        additionalHeaders: { 'custom-header': 'value' }
+                    }
+                }
+            });
+
+            const res = await server.inject('/file');
+            expect(res.headers['custom-header']).to.equal('value');
+        });
     });
 });


### PR DESCRIPTION
[Implemented #83 ](https://github.com/hapijs/inert/issues/83)
```
server.route({
                method: 'GET',
                path: '/file',
                handler: {
                    file: {
                        path: Path.join(__dirname, 'file/image.png'),
                        additionalHeaders: { 'custom-header': 'value' }
                    }
                }
            });
```
and 
```
server.route({
                method: 'GET',
                path: '/{path*}',
                handler: {
                    directory: {
                        path: Path.join(__dirname, './directory/'),
                        additionalHeaders: { 'custom-header': 'value' }
                    }
                }
            });
```