### PR TITLE
Directory listing has broken links

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -83,9 +83,12 @@ exports.handler = function (route, options) {
             throw Boom.notFound(null, {});
         }
 
-        // Adding trailing slash to top level path if stripTrailingSlash is true
+        // Adding trailing slash to top level path
         // To build correct urls for listings
-        if (!selection && request.server.settings.router.stripTrailingSlash) {
+        // if stripTrailingSlash is true
+        // or if path ends without /
+        if (!selection &&
+            (request.server.settings.router.stripTrailingSlash || !request.path.endsWith('/'))) {
             request.path += '/';
         }
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -83,6 +83,12 @@ exports.handler = function (route, options) {
             throw Boom.notFound(null, {});
         }
 
+        // Adding trailing Slash to top level path if stripTrailingSlash
+        // To build correct urls for listings
+        if (!selection && request.server.settings.router.stripTrailingSlash) {
+            request.path += '/';
+        }
+
         // Generate response
 
         const resource = request.path;

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -83,7 +83,7 @@ exports.handler = function (route, options) {
             throw Boom.notFound(null, {});
         }
 
-        // Adding trailing Slash to top level path if stripTrailingSlash
+        // Adding trailing slash to top level path if stripTrailingSlash is true
         // To build correct urls for listings
         if (!selection && request.server.settings.router.stripTrailingSlash) {
             request.path += '/';

--- a/test/directory.js
+++ b/test/directory.js
@@ -178,6 +178,25 @@ describe('directory', () => {
             expect(res.payload).to.contain('href="/showindex/package.json"');
         });
 
+        it('does contain / for sub path listing when top level does not have / at the end', async () => {
+
+            const server = await provisionServer();
+
+            server.route({ method: 'GET',
+                path: '/showindex/{path*}',
+                handler: {
+                    directory: {
+                        path: './',
+                        listing: true
+                    }
+                }
+            });
+
+            const res = await server.inject('/showindex');
+            expect(res.statusCode).to.equal(200);
+            expect(res.payload).to.contain('href="/showindex/file.js"');
+        });
+
         it('has the correct link to sub folders when inside of a sub folder listing', async () => {
 
             const server = await provisionServer();

--- a/test/directory.js
+++ b/test/directory.js
@@ -159,6 +159,25 @@ describe('directory', () => {
             expect(res.payload).to.not.contain('//');
         });
 
+        it('does contain / for sub path listing when stripTrailingSlash is true', async () => {
+
+            const server = await provisionServer({ router: { stripTrailingSlash: true } });
+
+            server.route({ method: 'GET',
+                path: '/showindex/{path*}',
+                handler: {
+                    directory: {
+                        path: './',
+                        listing: true
+                    }
+                }
+            });
+
+            const res = await server.inject('/showindex/');
+            expect(res.statusCode).to.equal(200);
+            expect(res.payload).to.contain('href="/showindex/package.json"');
+        });
+
         it('has the correct link to sub folders when inside of a sub folder listing', async () => {
 
             const server = await provisionServer();


### PR DESCRIPTION
I came across with this issue https://github.com/hapijs/inert/issues/119.
As was described, when we hit top level path, then links are built incorrectly `"/logstrace_context.log"`.
 It's just happening when `stripTrailingSlash` is set true or last slash is omitted. 

We need to be sure when we hit top level path, we have slash at the end of it.

Tests were added and coverage wasn't decreased.  