### PR TITLE
Add coverage for duplicate file closes

### DIFF
--- a/test/file.js
+++ b/test/file.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ChildProcess = require('child_process');
+const Events = require('events');
 const Fs = require('fs');
 const Os = require('os');
 const Path = require('path');
@@ -741,7 +742,9 @@ describe('file', () => {
 
         it('closes file handlers when not using a manually open file stream', { skip: process.platform === 'win32' }, async () => {
 
-            const server = await provisionServer();
+            // This test doesn't rely on inert but is a fair test of hapi's handling of (file) streams
+            const server = Hapi.server();
+
             server.route({
                 method: 'GET',
                 path: '/file',
@@ -754,6 +757,14 @@ describe('file', () => {
             const res1 = await server.inject('/file');
             const res2 = await server.inject({ url: '/file', headers: { 'if-none-match': res1.headers.etag } });
             expect(res2.statusCode).to.equal(304);
+
+            const file1 = res1.request.response.source;
+            const file2 = res2.request.response.source;
+
+            await Promise.all([
+                file1.closed || Events.once(file1, 'close'),
+                file2.closed || Events.once(file2, 'close')
+            ]);
 
             await new Promise((resolve) => {
 


### PR DESCRIPTION
As of https://github.com/hapijs/hapi/pull/4257 hapi no longer naturally causes a file response to be closed multiple times, however we don't want inert to rely on this assumption quite yet.  So for hapi v20.1.4+ this new test should ensure we're covered.  The branch in question is here: https://github.com/hapijs/inert/blob/f932e40afed47dc2eba9572d19b180b9dee0f782/lib/file.js#L248-L252

This should fix CI for #157.