### PR TITLE
fix: return 404 for ENOTDIR

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -34,7 +34,7 @@ exports.File = class {
         catch (err) {
             const data = { path: this.path };
 
-            if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT') {
+            if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT' || err.code === 'ENOTDIR') {
                 throw Boom.notFound(null, data);
             }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -15,6 +15,7 @@ const internals = {
     }
 };
 
+const notFound = ['ENOENT', 'ENOTDIR'];
 
 exports.File = class {
 
@@ -34,7 +35,7 @@ exports.File = class {
         catch (err) {
             const data = { path: this.path };
 
-            if (this.path.indexOf('\u0000') !== -1 || err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+            if (this.path.indexOf('\u0000') !== -1 || notFound.includes(err.code)) {
                 throw Boom.notFound(null, data);
             }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -12,10 +12,9 @@ const internals = {
     methods: {
         promised: ['open', 'close', 'fstat', 'readdir'],
         raw: ['createReadStream']
-    }
+    },
+    notFound: new Set(['ENOENT', 'ENOTDIR'])
 };
-
-const notFound = ['ENOENT', 'ENOTDIR'];
 
 exports.File = class {
 
@@ -35,7 +34,7 @@ exports.File = class {
         catch (err) {
             const data = { path: this.path };
 
-            if (this.path.indexOf('\u0000') !== -1 || notFound.includes(err.code)) {
+            if (this.path.indexOf('\u0000') !== -1 || internals.notFound.has(err.code)) {
                 throw Boom.notFound(null, data);
             }
 

--- a/test/directory.js
+++ b/test/directory.js
@@ -80,7 +80,7 @@ describe('directory', () => {
 
             const res = await server.inject('/directory/directory.js/xyz');
             expect(res.statusCode).to.equal(404);
-            expect(res.request.response._error.data.path).to.equal(Path.join(__dirname, 'xyz'));
+            expect(res.request.response._error.data.path).to.equal(Path.join(__dirname, 'directory.js', 'xyz'));
         });
 
         it('returns a file when requesting a file from the directory', async () => {

--- a/test/directory.js
+++ b/test/directory.js
@@ -73,6 +73,16 @@ describe('directory', () => {
             expect(res.request.response._error.data.path).to.equal(Path.join(__dirname, 'xyz'));
         });
 
+        it('returns a 404 when requesting an unknown file when part of the path matches a filename', async () => {
+
+            const server = await provisionServer();
+            server.route({ method: 'GET', path: '/directory/{path*}', handler: { directory: { path: './' } } });
+
+            const res = await server.inject('/directory/directory.js/xyz');
+            expect(res.statusCode).to.equal(404);
+            expect(res.request.response._error.data.path).to.equal(Path.join(__dirname, 'xyz'));
+        });
+
         it('returns a file when requesting a file from the directory', async () => {
 
             const server = await provisionServer();


### PR DESCRIPTION
Inert will return error 500 for non-existing files, when part of the path resembles an existing file.
For example if /a/b/c.html is existing file, requesting /a/b/c.html/d will return 500 instead of 404.

`ENOTDIR` is listed here https://nodejs.org/api/errors.html#common-system-errors