### PR TITLE
Support node v18 and hapi v21, drop node v12 and hapi v19

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-plugin.yml@workflow-min-hapi-version
+    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
     with:
       min-node-version: 14
       min-hapi-version: 20

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@workflow-min-hapi-version
-      with:
-        min-node-version: 14
-        min-hapi-version: 20
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -9,4 +9,7 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    uses: hapijs/.github/.github/workflows/ci-plugin.yml@workflow-min-hapi-version
+      with:
+        min-node-version: 14
+        min-hapi-version: 20

--- a/API.md
+++ b/API.md
@@ -24,6 +24,8 @@ The following creates a basic static file server that can be used to serve html 
 const Path = require('path');
 const Hapi = require('@hapi/hapi');
 const Inert = require('@hapi/inert');
+// In ESM, may import as:
+// import { inertPlugin } from '@hapi/inert';
 
 const server = new Hapi.Server({
     port: 3000,

--- a/API.md
+++ b/API.md
@@ -24,8 +24,6 @@ The following creates a basic static file server that can be used to serve html 
 const Path = require('path');
 const Hapi = require('@hapi/hapi');
 const Inert = require('@hapi/inert');
-// In ESM, may import as:
-// import { inertPlugin } from '@hapi/inert';
 
 const server = new Hapi.Server({
     port: 3000,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014-2019, Gil Pedersen  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2014-2019, Gil Pedersen
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -60,11 +60,11 @@ exports.handler = function (route, options) {
 
     const handler = async (request, reply) => {
 
-        const paths = normalized || internals.resolvePathOption(settings.path.call(null, request));
+        const paths = normalized ?? internals.resolvePathOption(settings.path.call(null, request));
 
         // Append parameter
 
-        const selection = request.params[paramName] || '';
+        const selection = request.params[paramName] ?? '';
 
         if (Path.isAbsolute(selection)) {
             throw Boom.notFound(null, {});

--- a/lib/file.js
+++ b/lib/file.js
@@ -106,7 +106,7 @@ internals.prepare = async function (response) {
     try {
         const stat = await file.openStat('r');
 
-        const start = settings.start || 0;
+        const start = settings.start ?? 0;
         if (settings.end !== undefined) {
             response.bytes(settings.end - start + 1);
         }
@@ -115,13 +115,13 @@ internals.prepare = async function (response) {
         }
 
         if (!response.headers['content-type']) {
-            response.type(request.server.mime.path(path).type || 'application/octet-stream');
+            response.type(request.server.mime.path(path).type ?? 'application/octet-stream');
         }
 
         response.header('last-modified', stat.mtime.toUTCString());
 
         if (settings.mode) {
-            const fileName = settings.filename || Path.basename(path);
+            const fileName = settings.filename ?? Path.basename(path);
             response.header('content-disposition', settings.mode + '; filename=' + encodeURIComponent(fileName));
         }
 
@@ -146,7 +146,7 @@ internals.marshal = async function (response) {
         settings.end === undefined &&
         request.server.settings.compression !== false) {
 
-        const lookupMap = settings.lookupMap || internals.defaultMap;
+        const lookupMap = settings.lookupMap ?? internals.defaultMap;
         const encoding = request.info.acceptEncoding;
         const extension = lookupMap.hasOwnProperty(encoding) ? lookupMap[encoding] : null;
         if (extension) {
@@ -232,7 +232,7 @@ internals.createStream = function (response) {
 
     const range = internals.addContentRange(response);
     const options = {
-        start: settings.start || 0,
+        start: settings.start ?? 0,
         end: settings.end
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ exports.plugin = {
     pkg: require('../package.json'),
     once: true,
     requirements: {
+        // NOTE v21 beta is included only prior to the release of v21, and will be removed.
         hapi: '>=20.0.0 || 21.0.0-beta.0'
     },
     register(server, options) {
@@ -47,3 +48,6 @@ exports.plugin = {
         server.decorate('toolkit', 'file', internals.fileMethod);
     }
 };
+
+// For ESM import ergonomics
+exports.inertPlugin = exports.plugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,8 +33,7 @@ exports.plugin = {
     pkg: require('../package.json'),
     once: true,
     requirements: {
-        // NOTE v21 beta is included only prior to the release of v21, and will be removed.
-        hapi: '>=20.0.0 || 21.0.0-beta.0'
+        hapi: '>=20.0.0'
     },
     register(server, options) {
 
@@ -48,6 +47,3 @@ exports.plugin = {
         server.decorate('toolkit', 'file', internals.fileMethod);
     }
 };
-
-// For ESM import ergonomics
-exports.inertPlugin = exports.plugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,15 +33,14 @@ exports.plugin = {
     pkg: require('../package.json'),
     once: true,
     requirements: {
-        hapi: '>=19.0.0'
+        hapi: '>=20.0.0 || 21.0.0-beta.0'
     },
-
     register(server, options) {
 
         Hoek.assert(Object.keys(options).length === 0, 'Inert does not support registration options');
-        const settings = Validate.attempt(Hoek.reach(server.settings.plugins, ['inert']) || {}, internals.schema, 'Invalid "inert" server options');
+        const settings = Validate.attempt(server.settings.plugins?.inert ?? {}, internals.schema, 'Invalid "inert" server options');
 
-        server.expose('_etags', settings.etagsCacheMaxSize > 0 ? new Etag.Cache(settings.etagsCacheMaxSize) : null);
+        server.expose('_etags', settings.etagsCacheMaxSize > 0 ? new Etag.Cache({ max: settings.etagsCacheMaxSize }) : null);
 
         server.decorate('handler', 'file', File.handler);
         server.decorate('handler', 'directory', Directory.handler);

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     ]
   },
   "dependencies": {
-    "@hapi/ammo": "5.x.x",
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x",
-    "lru-cache": "^6.0.0"
+    "@hapi/ammo": "^6.0.0",
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0",
+    "lru-cache": "^7.10.2"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/file": "2.x.x",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/file": "^3.0.0",
+    "@hapi/hapi": "21.0.0-beta.0",
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -f -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "^6.0.0",
     "@hapi/file": "^3.0.0",
-    "@hapi/hapi": "21.0.0-beta.0",
+    "@hapi/hapi": "21.0.0-beta.1",
     "@hapi/lab": "^25.0.1"
   },
   "scripts": {

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Inert;
+
+    before(async () => {
+
+        Inert = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Inert)).to.equal([
+            'default',
+            'inertPlugin',
+            'plugin'
+        ]);
+    });
+});

--- a/test/esm.js
+++ b/test/esm.js
@@ -21,7 +21,6 @@ describe('import()', () => {
 
         expect(Object.keys(Inert)).to.equal([
             'default',
-            'inertPlugin',
             'plugin'
         ]);
     });


### PR DESCRIPTION
 - Test on node v14+ and hapi v20+.
 - Update to node v18-compatible versions of hapi modules, update lru-cache.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as inert v7.

This PR may be used as an example of a plugin update for node v18 and hapi v21.  Here's the checklist:
 - [x] Update the license for the current year.
 - [x] Update the workflow file to test on node v14+ and hapi v20+.
 - [x] Ensure that node support is up-to-date on `engines` field in package.json if present (supports node v14+).
 - [x] Ensure that node and hapi support is up-to-date on plugin `requirements` attribute if present (supports node v14+ and hapi v20+).
 - [x] Update JS syntax, utilizing optional chaining `x?.y` and nullish coalescing `(x ?? y)` where appropriate.
 - [x] Update dependencies.
 - [x] Add a test file `esm/test.js` testing the module's ESM exports.
 - [x] We decided not to do this for plugins. ~~Add an additional explicitly-named export for each plugin, e.g. `inertPlugin` for inert, `visionPlugin` for vision, etc.~~